### PR TITLE
Add amoCRM webhook lead Zapier script

### DIFF
--- a/zapier-scripts/README.md
+++ b/zapier-scripts/README.md
@@ -1,0 +1,20 @@
+# Zapier Scripts
+
+This directory contains standalone scripts for use in Zapier.
+
+## zapier-amocrm-webhook-lead.js
+
+Fetches full lead information from amoCRM using data provided by an incoming
+webhook. The script requires an amoCRM access token and returns the enriched
+lead object together with the original webhook body.
+
+### Usage
+
+```js
+import execute from "./zapier-amocrm-webhook-lead.js";
+
+const result = await execute({ body, token: "your_access_token" }, fetch);
+```
+
+If `token` is omitted, the script will look for the `AMOCRM_ACCESS_TOKEN`
+environment variable.

--- a/zapier-scripts/zapier-amocrm-webhook-lead.js
+++ b/zapier-scripts/zapier-amocrm-webhook-lead.js
@@ -1,0 +1,43 @@
+export default async function execute(inputData = {}, fetchParam) {
+  const body = inputData.body || {};
+  const token = inputData.token || process.env.AMOCRM_ACCESS_TOKEN;
+  if (!token) throw new Error("AMOCRM access token is required");
+
+  const baseUrl = (body["account[_links][self]"] || "").replace(/\/$/, "");
+  const leadId = body["leads[add][0][id]"];
+  if (!baseUrl || !leadId) throw new Error("Invalid webhook body");
+
+  const fetchFn = fetchParam || (typeof fetch !== "undefined" ? fetch : null);
+  if (!fetchFn) throw new Error("fetch is not available");
+
+  async function amoGet(path) {
+    const res = await fetchFn(`${baseUrl}${path}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`amoCRM request failed: ${res.status} ${text}`);
+    }
+    return res.json();
+  }
+
+  const lead = await amoGet(`/api/v4/leads/${leadId}?with=contacts`);
+  const detailedContacts = [];
+  const contacts =
+    lead._embedded && Array.isArray(lead._embedded.contacts)
+      ? lead._embedded.contacts
+      : [];
+
+  for (const c of contacts) {
+    const full = await amoGet(`/api/v4/contacts/${c.id}`);
+    detailedContacts.push(full);
+  }
+
+  lead.contactsDetailed = detailedContacts;
+
+  return { body, lead };
+}

--- a/zapier-scripts/zapier-amocrm-webhook-lead.test.js
+++ b/zapier-scripts/zapier-amocrm-webhook-lead.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import execute from "./zapier-amocrm-webhook-lead.js";
+
+const inputBody = {
+  "account[_links][self]": "https://example.amocrm.ru",
+  "leads[add][0][id]": "123",
+};
+
+describe("zapier-amocrm-webhook-lead", () => {
+  it("fetches lead and returns body", async () => {
+    const fetchMock = async (url) => {
+      if (url.endsWith("/api/v4/leads/123?with=contacts")) {
+        return {
+          ok: true,
+          json: async () => ({ id: 123, _embedded: { contacts: [{ id: 1 }] } }),
+        };
+      }
+      if (url.endsWith("/api/v4/contacts/1")) {
+        return { ok: true, json: async () => ({ id: 1, name: "John" }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    };
+
+    const result = await execute({ body: inputBody, token: "t" }, fetchMock);
+    expect(result.body).toEqual(inputBody);
+    expect(result.lead.id).toBe(123);
+    expect(result.lead.contactsDetailed[0].id).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- create `zapier-scripts` folder
- implement `zapier-amocrm-webhook-lead.js` to fetch full amoCRM lead info
- add README and unit test for the new script

## Testing
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_68480bb0b1f0832c8f0ced37816dcb50