### PR TITLE
Add data directory override for objects cache

### DIFF
--- a/.windsurf/workflows/test-and-fix.md
+++ b/.windsurf/workflows/test-and-fix.md
@@ -1,0 +1,7 @@
+---
+description: Run tests and fix errors
+---
+
+- Run `npm run test-full`
+- Fix first test
+- Fix remain tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@eslint/js": "^9.27.0",
         "@modelcontextprotocol/inspector": "^0.11.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.17.30",
         "cross-env": "^7.0.3",
         "eslint": "^8.57.1",
@@ -2030,6 +2031,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@eslint/js": "^9.27.0",
     "@modelcontextprotocol/inspector": "^0.11.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.17.30",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",

--- a/src/lib/planfixObjects.ts
+++ b/src/lib/planfixObjects.ts
@@ -100,18 +100,32 @@ export async function getObjectsNames(
   return Object.values(objects).map((o) => o.name);
 }
 
-export async function getFieldDirectoryId(
-  objectName: string,
-  fieldName: string,
-  cachePath: string = getDefaultCachePath(),
-): Promise<number | undefined> {
+export async function getFieldDirectoryId({
+  objectName,
+  fieldName,
+  fieldId,
+  cachePath,
+}: {
+  objectName: string;
+  fieldName?: string;
+  fieldId?: number;
+  cachePath?: string;
+}): Promise<number | undefined> {
   const objects = await ensureCache(cachePath);
   const obj = objects[objectName];
   if (!obj) return undefined;
   interface CustomField {
-    field: { name: string; directoryId?: number };
+    field: { name: string; directoryId?: number; id?: number };
   }
-  const fields = (obj as { customFieldData?: CustomField[] }).customFieldData;
-  const field = fields?.find((f) => f.field.name === fieldName);
+  let field: CustomField | undefined;
+  if (fieldId) {
+    field = (obj as { customFieldData?: CustomField[] }).customFieldData?.find(
+      (f) => f.field.id === fieldId,
+    );
+  } else {
+    field = (obj as { customFieldData?: CustomField[] }).customFieldData?.find(
+      (f) => f.field.name === fieldName,
+    );
+  }
   return field?.field.directoryId;
 }

--- a/src/lib/planfixObjects.ts
+++ b/src/lib/planfixObjects.ts
@@ -53,8 +53,11 @@ async function fetchObjects(): Promise<Record<string, PlanfixObject>> {
 }
 
 async function updateCache(cachePath: string) {
+  const started = Date.now();
   const data = await fetchObjects();
   await writeCache(data, cachePath);
+  const duration = Math.round((Date.now() - started) / 1000);
+  log(`[planfixObjects] Cache updated: ${cachePath} (${duration}s)`);
   return data;
 }
 

--- a/src/lib/planfixObjects.ts
+++ b/src/lib/planfixObjects.ts
@@ -1,0 +1,114 @@
+import fs from "fs";
+import fsp from "fs/promises";
+import os from "os";
+import path from "path";
+import yaml from "js-yaml";
+import { planfixClient } from "./planfix-client.js";
+import { log } from "../helpers.js";
+
+export interface PlanfixObject {
+  id: number;
+  name: string;
+  [key: string]: unknown;
+}
+
+const CACHE_FILE_NAME = "planfix-objects.yml";
+const DATA_CACHE_FILE_NAME = "planfix-cache.yml";
+const CACHE_MAX_AGE = 3 * 24 * 60 * 60 * 1000; // 3 days in ms
+
+function getDefaultCachePath(): string {
+  const dataDir = path.join(process.cwd(), "data");
+  if (fs.existsSync(dataDir) && fs.statSync(dataDir).isDirectory()) {
+    return path.join(dataDir, DATA_CACHE_FILE_NAME);
+  }
+  return path.join(os.tmpdir(), CACHE_FILE_NAME);
+}
+
+async function writeCache(
+  data: Record<string, PlanfixObject>,
+  cachePath: string,
+) {
+  await fsp.writeFile(cachePath, yaml.dump(data), "utf-8");
+}
+
+async function readCache(
+  cachePath: string,
+): Promise<Record<string, PlanfixObject>> {
+  const content = await fsp.readFile(cachePath, "utf-8");
+  return (yaml.load(content) as Record<string, PlanfixObject>) || {};
+}
+
+async function fetchObjects(): Promise<Record<string, PlanfixObject>> {
+  const list = (await planfixClient.post<{ objects?: { id: number }[] }>(
+    "object/list",
+  )) as { objects?: { id: number }[] };
+  const result: Record<string, PlanfixObject> = {};
+  for (const item of list.objects || []) {
+    const details = (await planfixClient.get<{ object: PlanfixObject }>(
+      `object/${item.id}`,
+    )) as { object: PlanfixObject };
+    result[details.object.name] = details.object;
+  }
+  return result;
+}
+
+async function updateCache(cachePath: string) {
+  const data = await fetchObjects();
+  await writeCache(data, cachePath);
+  return data;
+}
+
+async function ensureCache(
+  cachePath: string = getDefaultCachePath(),
+): Promise<Record<string, PlanfixObject>> {
+  try {
+    const stats = fs.existsSync(cachePath) ? fs.statSync(cachePath) : null;
+    if (stats) {
+      const age = Date.now() - stats.mtimeMs;
+      const cached = await readCache(cachePath);
+      if (age > CACHE_MAX_AGE) {
+        log(
+          `[planfixObjects] Cache outdated, updating in background: ${cachePath}`,
+        );
+        updateCache(cachePath).catch((e) =>
+          log(
+            `[planfixObjects] Background update failed: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        );
+      }
+      return cached;
+    }
+  } catch (e) {
+    log(
+      `[planfixObjects] Failed to read cache: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+  return updateCache(cachePath);
+}
+
+export async function getObjects(cachePath: string = getDefaultCachePath()) {
+  return ensureCache(cachePath);
+}
+
+export async function getObjectsNames(
+  cachePath: string = getDefaultCachePath(),
+): Promise<string[]> {
+  const objects = await ensureCache(cachePath);
+  return Object.values(objects).map((o) => o.name);
+}
+
+export async function getFieldDirectoryId(
+  objectName: string,
+  fieldName: string,
+  cachePath: string = getDefaultCachePath(),
+): Promise<number | undefined> {
+  const objects = await ensureCache(cachePath);
+  const obj = objects[objectName];
+  if (!obj) return undefined;
+  interface CustomField {
+    field: { name: string; directoryId?: number };
+  }
+  const fields = (obj as { customFieldData?: CustomField[] }).customFieldData;
+  const field = fields?.find((f) => f.field.name === fieldName);
+  return field?.field.directoryId;
+}

--- a/src/tools/planfix_create_task.integration.test.ts
+++ b/src/tools/planfix_create_task.integration.test.ts
@@ -9,6 +9,7 @@ describe("planfix_create_task tool prod", () => {
       email: "pop.stas@gmail.com",
       phone: "+79222229531",
       agency: "Тестовое агентство",
+      object: "Задача",
       leadSource: "Zapier",
       title: "Test task title",
       telegram: "popstas",

--- a/src/tools/planfix_create_task.ts
+++ b/src/tools/planfix_create_task.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import { getToolWithHandler } from "../helpers.js";
+import { getFieldDirectoryId } from "../lib/planfixObjects.js";
 import {
   addToLeadTask,
   AddToLeadTaskOutputSchema,
 } from "./planfix_add_to_lead_task.js";
 
 export const PlanfixCreateTaskInputSchema = z.object({
+  object: z.string().optional(),
   title: z.string().describe("Task title"),
   name: z.string().optional(),
   nameTranslated: z.string().optional(),
@@ -28,8 +30,21 @@ export async function planfixCreateTask(
 
   const header = title;
   const messageParts = [];
-  if (leadSource) messageParts.push(`Источник: ${leadSource}`);
-  if (referral) messageParts.push(`Реферал: ${referral}`);
+  if (leadSource) {
+    messageParts.push(`Источник: ${leadSource}`);
+    if (args.object) {
+      const directoryId = await getFieldDirectoryId(
+        args.object,
+        "leadSource",
+      );
+      if (directoryId) {
+        messageParts.push(`Источник: ${directoryId}`);
+      }
+    }
+  }
+  if (referral) {
+    messageParts.push(`Реферал: ${referral}`);
+  }
   const message = messageParts.join("\n");
 
   return await addToLeadTask({

--- a/src/tools/planfix_create_task.ts
+++ b/src/tools/planfix_create_task.ts
@@ -5,6 +5,7 @@ import {
   addToLeadTask,
   AddToLeadTaskOutputSchema,
 } from "./planfix_add_to_lead_task.js";
+import { PLANFIX_FIELD_IDS } from "../config.js";
 
 export const PlanfixCreateTaskInputSchema = z.object({
   object: z.string().optional(),
@@ -33,12 +34,12 @@ export async function planfixCreateTask(
   if (leadSource) {
     messageParts.push(`Источник: ${leadSource}`);
     if (args.object) {
-      const directoryId = await getFieldDirectoryId(
-        args.object,
-        "leadSource",
-      );
+      const directoryId = await getFieldDirectoryId({
+        objectName: args.object,
+        fieldId: PLANFIX_FIELD_IDS.leadSource,
+      });
       if (directoryId) {
-        messageParts.push(`Источник: ${directoryId}`);
+        // TODO: search_directory_entry(directoryId, leadSource)
       }
     }
   }


### PR DESCRIPTION
## Summary
- update default cache path in `planfixObjects` to use `./data/planfix-cache.yml` if a local data folder exists

## Testing
- `npm run test-full` *(fails: Cannot find module 'url' or its corresponding type declarations)*
- `npx prettier --write src/lib/planfixObjects.ts`

------
https://chatgpt.com/codex/tasks/task_e_68483e7285b4832c9e82781b1ad6fc38