### PR TITLE
Add Planfix directory lookup and caching

### DIFF
--- a/.windsurf/workflows/lint-and-fix.md
+++ b/.windsurf/workflows/lint-and-fix.md
@@ -1,0 +1,9 @@
+---
+description: Run lint and fix errors
+---
+
+- Run `npm run lint src`
+- Fix first lint error
+- Fix remain lint errors
+- Run tests at the end
+- Скажи голосом, когда закончишь

--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ const objects = await planfixClient.post('object/list', {
 - `createComment`: Add a comment to a task
 - `getChildTasks`: Retrieve all child tasks of a parent task
 
+### Directory Management
+
+- `planfix_search_directory`: Search directories by name
+- `planfix_search_directory_entry`: Search directory entry by directory name and entry name
+
 ### User Management
 
 - `searchManager`: Find a manager by email

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.2",
+        "better-sqlite3": "^9.0.0",
         "commander": "^14.0.0",
         "dotenv": "^16.5.0",
         "execa": "^9.5.2",
@@ -2582,6 +2583,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.0.tgz",
@@ -2769,6 +2790,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -3096,6 +3123,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -3104,6 +3146,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -3120,6 +3171,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node-es": {
@@ -3205,6 +3265,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -3574,6 +3643,15 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
@@ -3781,6 +3859,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3936,6 +4020,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4050,6 +4140,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -4293,6 +4389,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -4685,6 +4787,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4716,6 +4830,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mqtt": {
       "version": "5.13.0",
@@ -4783,6 +4903,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4797,6 +4923,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -5145,6 +5283,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5224,6 +5388,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5292,6 +5466,30 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -5612,7 +5810,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5863,6 +6060,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/smart-buffer": {
@@ -6121,6 +6363,83 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6301,6 +6620,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "js-yaml": "^4.1.0",
     "mqtt": "^5.13.0",
     "node-fetch": "^3.3.2",
+    "better-sqlite3": "^9.0.0",
     "tsx": "^4.19.4",
     "zod": "^3.24.3",
     "zod-to-json-schema": "^3.24.5"

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,7 +23,9 @@ export const PLANFIX_DRY_RUN = Boolean(process.env.PLANFIX_DRY_RUN);
 export const PLANFIX_FIELD_IDS = {
   email: Number(process.env.PLANFIX_FIELD_ID_EMAIL || 108),
   phone: Number(process.env.PLANFIX_FIELD_ID_PHONE || 105),
-  telegram: process.env.PLANFIX_FIELD_ID_TELEGRAM_CUSTOM ? 0: Number(process.env.PLANFIX_FIELD_ID_TELEGRAM || 131),
+  telegram: process.env.PLANFIX_FIELD_ID_TELEGRAM_CUSTOM
+    ? 0
+    : Number(process.env.PLANFIX_FIELD_ID_TELEGRAM || 131),
   telegramCustom: Number(process.env.PLANFIX_FIELD_ID_TELEGRAM_CUSTOM),
   client: Number(process.env.PLANFIX_FIELD_ID_CLIENT),
   manager: Number(process.env.PLANFIX_FIELD_ID_MANAGER),

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -67,7 +67,7 @@ export async function planfixRequest<T = unknown>({
   path,
   body,
   method = "POST",
-  cacheTime = 3600,
+  cacheTime = 0,
 }: PlanfixRequestArgs): Promise<T> {
   if (!PLANFIX_ACCOUNT) {
     throw new Error("PLANFIX_ACCOUNT is not defined");
@@ -78,6 +78,7 @@ export async function planfixRequest<T = unknown>({
   if (cacheTime > 0) {
     const cached = await cache.get<T>(cacheKey);
     if (cached !== undefined) {
+      log(`[planfixRequest] Cache hit for ${path}`);
       return cached;
     }
   }
@@ -109,7 +110,7 @@ export async function planfixRequest<T = unknown>({
   const result = await response.json();
 
   log(
-    `[planfixRequest] ${response.status} ${method} ${PLANFIX_BASE_URL}${requestUrl}`,
+    `[planfixRequest] ${response.status} ${method} ${PLANFIX_BASE_URL}${requestUrl}, body: ${requestBody}`,
   );
 
   if (!response.ok) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { execa } from "execa";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { getCacheProvider } from "./lib/cache.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -55,16 +56,33 @@ export function getToolWithHandler<
   };
 }
 
-export async function planfixRequest<T = unknown>(
-  url: string,
-  body?: Record<string, unknown>,
-  method: "GET" | "POST" = "POST",
-): Promise<T> {
+export interface PlanfixRequestArgs {
+  path: string;
+  body?: Record<string, unknown>;
+  method?: "GET" | "POST";
+  cacheTime?: number;
+}
+
+export async function planfixRequest<T = unknown>({
+  path,
+  body,
+  method = "POST",
+  cacheTime = 3600,
+}: PlanfixRequestArgs): Promise<T> {
   if (!PLANFIX_ACCOUNT) {
     throw new Error("PLANFIX_ACCOUNT is not defined");
   }
 
-  let requestUrl = url;
+  const cache = getCacheProvider();
+  const cacheKey = JSON.stringify({ path, body, method });
+  if (cacheTime > 0) {
+    const cached = await cache.get<T>(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+
+  let requestUrl = path;
   let requestBody: string | undefined;
 
   if (method === "GET" && body) {
@@ -76,8 +94,8 @@ export async function planfixRequest<T = unknown>(
     });
     const queryString = params.toString();
     requestUrl = queryString
-      ? `${url}${url.includes("?") ? "&" : "?"}${queryString}`
-      : url;
+      ? `${path}${path.includes("?") ? "&" : "?"}${queryString}`
+      : path;
   } else if (body) {
     requestBody = JSON.stringify(body);
   }
@@ -90,12 +108,20 @@ export async function planfixRequest<T = unknown>(
 
   const result = await response.json();
 
-  log(`[planfixRequest] ${response.status} ${method} ${PLANFIX_BASE_URL}${requestUrl}`);
+  log(
+    `[planfixRequest] ${response.status} ${method} ${PLANFIX_BASE_URL}${requestUrl}`,
+  );
 
   if (!response.ok) {
-    log(`[planfixRequest] HTTP error! Status: ${response.status}, ${result.error}`);
+    log(
+      `[planfixRequest] HTTP error! Status: ${response.status}, ${result.error}`,
+    );
     log(`[planfixRequest] Body: ${requestBody}`);
     throw new Error(result.error || `Unknown error: ${response.status}`);
+  }
+
+  if (cacheTime > 0) {
+    await cache.set(cacheKey, result, cacheTime);
   }
 
   return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ import planfix_request from "./tools/planfix_request.js";
 import planfix_run_report from "./tools/planfix_run_report.js";
 import planfix_search_company from "./tools/planfix_search_company.js";
 import planfix_search_contact from "./tools/planfix_search_contact.js";
+import planfix_search_directory from "./tools/planfix_search_directory.js";
+import planfix_search_directory_entry from "./tools/planfix_search_directory_entry.js";
 import planfix_search_lead_task from "./tools/planfix_search_lead_task.js";
 import planfix_search_manager from "./tools/planfix_search_manager.js";
 import planfix_search_project from "./tools/planfix_search_project.js";
@@ -43,6 +45,8 @@ const TOOLS: ToolWithHandler[] = [
   planfix_run_report,
   planfix_search_company,
   planfix_search_contact,
+  planfix_search_directory,
+  planfix_search_directory_entry,
   planfix_search_lead_task,
   planfix_search_manager,
   planfix_search_project,

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -7,7 +7,7 @@ export interface CacheProvider {
 }
 
 export class SqliteCache implements CacheProvider {
-  private db: any;
+  private db: ReturnType<typeof DatabaseConstructor>;
   constructor(dbPath: string) {
     this.db = new DatabaseConstructor(dbPath);
     this.db.exec(

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,50 @@
+import path from "path";
+import DatabaseConstructor from "better-sqlite3";
+
+export interface CacheProvider {
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(key: string, value: T, ttl?: number): Promise<void>;
+}
+
+export class SqliteCache implements CacheProvider {
+  private db: any;
+  constructor(dbPath: string) {
+    this.db = new DatabaseConstructor(dbPath);
+    this.db.exec(
+      "CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value TEXT, expiresAt INTEGER)",
+    );
+  }
+  async get<T>(key: string): Promise<T | undefined> {
+    const row = this.db
+      .prepare("SELECT value, expiresAt FROM cache WHERE key=?")
+      .get(key) as { value: string; expiresAt: number } | undefined;
+    if (!row) return undefined;
+    if (row.expiresAt && row.expiresAt < Date.now()) {
+      this.db.prepare("DELETE FROM cache WHERE key=?").run(key);
+      return undefined;
+    }
+    try {
+      return JSON.parse(row.value) as T;
+    } catch {
+      return undefined;
+    }
+  }
+  async set<T>(key: string, value: T, ttl: number = 3600): Promise<void> {
+    const expiresAt = Date.now() + ttl * 1000;
+    const valueStr = JSON.stringify(value);
+    this.db
+      .prepare(
+        "INSERT OR REPLACE INTO cache(key,value,expiresAt) VALUES(?,?,?)",
+      )
+      .run(key, valueStr, expiresAt);
+  }
+}
+
+let provider: CacheProvider | undefined;
+export function getCacheProvider(): CacheProvider {
+  if (!provider) {
+    const dbPath = path.join(process.cwd(), "data", "planfix-cache.sqlite3");
+    provider = new SqliteCache(dbPath);
+  }
+  return provider;
+}

--- a/src/lib/planfix-client.ts
+++ b/src/lib/planfix-client.ts
@@ -33,11 +33,15 @@ export class PlanfixClient {
 
       // For GET requests, use data as query params
       if (method === "GET") {
-        return (await planfixRequest(path, data, "GET")) as T;
+        return (await planfixRequest({ path, body: data, method: "GET" })) as T;
       }
       // For POST/PUT/DELETE/PATCH, use data as request body
       else if (method === "POST") {
-        return (await planfixRequest(path, data, "POST")) as T;
+        return (await planfixRequest({
+          path,
+          body: data,
+          method: "POST",
+        })) as T;
       }
       // For other methods, convert to POST with _method parameter
       else {
@@ -45,7 +49,11 @@ export class PlanfixClient {
           ...data,
           _method: method,
         };
-        return (await planfixRequest(path, requestData, "POST")) as T;
+        return (await planfixRequest({
+          path,
+          body: requestData,
+          method: "POST",
+        })) as T;
       }
     } catch (error) {
       console.error(`[PlanfixClient] Request to ${path} failed:`, error);

--- a/src/lib/planfixDirectory.test.ts
+++ b/src/lib/planfixDirectory.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { getDirectoryFields } from "./planfixDirectory.js";
+import { log, planfixRequest } from "../helpers.js";
+
+// Mock the helpers module
+vi.mock("../helpers.js", () => ({
+  log: vi.fn(),
+  planfixRequest: vi.fn(),
+}));
+
+// Create type-safe mocks
+const mockedLog = vi.mocked(log);
+const mockedPlanfixRequest = vi.mocked(planfixRequest);
+
+describe("getDirectoryFields", () => {
+  const mockDirectoryId = 7458;
+  const mockFields = [
+    { id: 23098, name: "name", type: 1, isSystem: true },
+    { id: 23099, name: "description", type: 1, isRequired: true },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return directory fields when the API call is successful", async () => {
+    // Mock successful API response
+    const mockResponse = {
+      directory: {
+        id: mockDirectoryId,
+        name: "Test Directory",
+        fields: mockFields,
+      },
+    };
+    
+    mockedPlanfixRequest.mockResolvedValueOnce(mockResponse);
+
+    const result = await getDirectoryFields(mockDirectoryId);
+
+    expect(mockedPlanfixRequest).toHaveBeenCalledWith({
+      path: `directory/${mockDirectoryId}?fields=id,name,fields`,
+      method: "GET",
+      cacheTime: 3600,
+    });
+    expect(result).toEqual(mockFields);
+    expect(mockedLog).not.toHaveBeenCalled();
+  });
+
+  it("should return undefined and log error when the API call fails", async () => {
+    const error = new Error("API Error");
+    mockedPlanfixRequest.mockRejectedValueOnce(error);
+
+    const result = await getDirectoryFields(mockDirectoryId);
+
+    expect(result).toBeUndefined();
+    expect(mockedLog).toHaveBeenCalledWith(`[getDirectoryFields] ${error.message}`);
+  });
+});

--- a/src/lib/planfixDirectory.ts
+++ b/src/lib/planfixDirectory.ts
@@ -1,44 +1,131 @@
-import { planfixClient } from "./planfix-client.js";
-import { log } from "../helpers.js";
+import { log, planfixRequest } from "../helpers.js";
+import type { CustomFieldDataType } from "../types.js";
 
 export interface DirectoryInfo {
   id: number;
   name: string;
 }
 
-export async function searchDirectory(
-  name: string,
-): Promise<DirectoryInfo | undefined> {
-  try {
-    const result = (await planfixClient.post<{
-      directories?: Array<{ id: number; name: string }>;
-    }>("directory/list", {
-      offset: 0,
-      pageSize: 100,
-      fields: "id,name",
-    })) as { directories?: Array<{ id: number; name: string }> };
-    return result.directories?.find((d) => d.name === name);
-  } catch (error) {
-    log(`[searchDirectory] ${(error as Error).message}`);
-    return undefined;
-  }
+export interface DirectoryEntry {
+  key: number;
+  name?: string;
+  customFieldData?: CustomFieldDataType[];
+}
+
+export interface DirectoryField {
+  id: number;
+  name: string;
+  type: number;
+  isSystem?: boolean;
+  isRequired?: boolean;
+  isReadOnly?: boolean;
+  isHidden?: boolean;
+  isDeleted?: boolean;
+  value?: unknown;
 }
 
 export async function searchDirectoryEntryById(
   directoryId: number,
+  fieldId: number,
   entryName: string,
 ): Promise<number | undefined> {
   try {
-    const result = (await planfixClient.post<{
-      directoryEntries?: Array<{ key: number; name?: string }>;
-    }>(`directory/${directoryId}/entry/list`, {
-      offset: 0,
-      pageSize: 100,
-      fields: "key,name",
-    })) as { directoryEntries?: Array<{ key: number; name?: string }> };
-    return result.directoryEntries?.find((e) => e.name === entryName)?.key;
+    const result = await planfixRequest<{
+      directoryEntries?: DirectoryEntry[];
+    }>({
+      path: `directory/${directoryId}/entry/list`,
+      method: "POST",
+      body: {
+        offset: 0,
+        pageSize: 100,
+        fields: `directory,parentKey,name,key,${fieldId}`,
+        entriesOnly: true,
+      },
+      cacheTime: 3600,
+    });
+    const entry = result.directoryEntries?.find((e: DirectoryEntry) => {
+      const name = e.customFieldData?.find(
+        (f: CustomFieldDataType) => f.field.id === fieldId,
+      )?.value;
+      return name === entryName;
+    });
+    return entry?.key;
   } catch (error) {
     log(`[searchDirectoryEntryById] ${(error as Error).message}`);
+    return undefined;
+  }
+}
+
+export async function searchAllDirectoryEntries(
+  directoryId: number,
+): Promise<DirectoryEntry[] | undefined> {
+  try {
+    const result = await planfixRequest<{
+      directoryEntries?: DirectoryEntry[];
+    }>({
+      path: `directory/${directoryId}/entry/list`,
+      method: "POST",
+      body: {
+        offset: 0,
+        pageSize: 100,
+        fields: "directory,parentKey,name,key",
+        entriesOnly: true,
+      },
+      cacheTime: 3600,
+    });
+    return result.directoryEntries;
+  } catch (error) {
+    log(`[searchAllDirectoryEntries] ${(error as Error).message}`);
+    return undefined;
+  }
+}
+
+/**
+ * Fetches metadata about a directory's fields
+ * @param directoryId The ID of the directory to fetch fields for
+ * @returns Array of directory fields or undefined if not found or on error
+ */
+export async function getDirectoryFields(
+  directoryId: number,
+): Promise<DirectoryField[] | undefined> {
+  try {
+    const result = await planfixRequest<{
+      directory: {
+        id: number;
+        name: string;
+        fields: DirectoryField[];
+      };
+    }>({
+      path: `directory/${directoryId}?fields=id,name,fields`,
+      method: "GET",
+      cacheTime: 3600,
+    });
+    return result.directory.fields;
+  } catch (error) {
+    log(`[getDirectoryFields] ${(error as Error).message}`);
+    return undefined;
+  }
+}
+
+export async function searchDirectory(
+  name: string,
+): Promise<DirectoryInfo | undefined> {
+  try {
+    const result = (await planfixRequest<{
+      directories?: Array<{ id: number; name: string }>;
+    }>({
+      path: "directory/list",
+      method: "POST",
+      body: {
+        offset: 0,
+        pageSize: 100,
+        fields: "id,name",
+      },
+      cacheTime: 3600,
+    })) as { directories?: Array<{ id: number; name: string }> };
+    return result.directories?.find((d) => d.name === name);
+  } catch (error) {
+    log(`[searchDirectory] ${(error as Error).message}`);
     return undefined;
   }
 }

--- a/src/lib/planfixDirectory.ts
+++ b/src/lib/planfixDirectory.ts
@@ -1,0 +1,44 @@
+import { planfixClient } from "./planfix-client.js";
+import { log } from "../helpers.js";
+
+export interface DirectoryInfo {
+  id: number;
+  name: string;
+}
+
+export async function searchDirectory(
+  name: string,
+): Promise<DirectoryInfo | undefined> {
+  try {
+    const result = (await planfixClient.post<{
+      directories?: Array<{ id: number; name: string }>;
+    }>("directory/list", {
+      offset: 0,
+      pageSize: 100,
+      fields: "id,name",
+    })) as { directories?: Array<{ id: number; name: string }> };
+    return result.directories?.find((d) => d.name === name);
+  } catch (error) {
+    log(`[searchDirectory] ${(error as Error).message}`);
+    return undefined;
+  }
+}
+
+export async function searchDirectoryEntryById(
+  directoryId: number,
+  entryName: string,
+): Promise<number | undefined> {
+  try {
+    const result = (await planfixClient.post<{
+      directoryEntries?: Array<{ key: number; name?: string }>;
+    }>(`directory/${directoryId}/entry/list`, {
+      offset: 0,
+      pageSize: 100,
+      fields: "key,name",
+    })) as { directoryEntries?: Array<{ key: number; name?: string }> };
+    return result.directoryEntries?.find((e) => e.name === entryName)?.key;
+  } catch (error) {
+    log(`[searchDirectoryEntryById] ${(error as Error).message}`);
+    return undefined;
+  }
+}

--- a/src/lib/planfixObjects.ts
+++ b/src/lib/planfixObjects.ts
@@ -102,17 +102,22 @@ export async function getObjectsNames(
 
 export async function getFieldDirectoryId({
   objectName,
+  objectId,
   fieldName,
   fieldId,
   cachePath,
 }: {
-  objectName: string;
+  objectName?: string;
+  objectId?: number;
   fieldName?: string;
   fieldId?: number;
   cachePath?: string;
 }): Promise<number | undefined> {
   const objects = await ensureCache(cachePath);
-  const obj = objects[objectName];
+  const obj = objectName
+    ? objects[objectName]
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    : Object.entries(objects).find(([_, o]) => o.id === objectId)?.[1];
   if (!obj) return undefined;
   interface CustomField {
     field: { name: string; directoryId?: number; id?: number };

--- a/src/tools/planfix_add_to_lead_task.ts
+++ b/src/tools/planfix_add_to_lead_task.ts
@@ -14,6 +14,8 @@ export const AddToLeadTaskInputSchema = UserDataInputSchema.extend({
   message: z.string(),
   managerEmail: z.string().optional(),
   project: z.string().optional(),
+  leadSource: z.string().optional(),
+  referral: z.string().optional(),
 });
 
 export const AddToLeadTaskOutputSchema = z.object({
@@ -99,6 +101,8 @@ export async function addToLeadTask({
   message,
   managerEmail,
   project,
+  leadSource,
+  referral,
 }: z.infer<typeof AddToLeadTaskInputSchema>): Promise<
   z.infer<typeof AddToLeadTaskOutputSchema>
 > {
@@ -187,6 +191,8 @@ export async function addToLeadTask({
         managerId: managerId ?? undefined,
         agencyId,
         project,
+        leadSource,
+        referral,
       });
       if (createLeadTaskResult.error) {
         return { taskId: 0, clientId: 0, error: createLeadTaskResult.error };

--- a/src/tools/planfix_create_comment.ts
+++ b/src/tools/planfix_create_comment.ts
@@ -64,10 +64,10 @@ export async function createComment({
       recipients,
     } as const;
 
-    const result = await planfixRequest<{ id: number }>(
-      `task/${taskId}/comments/`,
-      postBody,
-    );
+    const result = await planfixRequest<{ id: number }>({
+      path: `task/${taskId}/comments/`,
+      body: postBody,
+    });
     return { commentId: result.id };
   } catch (error: unknown) {
     const errorMessage =

--- a/src/tools/planfix_create_contact.ts
+++ b/src/tools/planfix_create_contact.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  PLANFIX_DRY_RUN,
-  PLANFIX_FIELD_IDS,
-} from "../config.js";
+import { PLANFIX_DRY_RUN, PLANFIX_FIELD_IDS } from "../config.js";
 import {
   getContactUrl,
   getToolWithHandler,
@@ -104,10 +101,10 @@ export async function createPlanfixContact(
       }
     }
 
-    const result = await planfixRequest<{ id: number }>(
-      `contact/`,
-      postBody as unknown as Record<string, unknown>,
-    );
+    const result = await planfixRequest<{ id: number }>({
+      path: `contact/`,
+      body: postBody as unknown as Record<string, unknown>,
+    });
     const contactId = result.id;
     const url = getContactUrl(contactId);
 

--- a/src/tools/planfix_create_lead_task.ts
+++ b/src/tools/planfix_create_lead_task.ts
@@ -138,10 +138,10 @@ export async function createLeadTask({
       return { taskId: mockId, url: `https://example.com/task/${mockId}` };
     }
 
-    const result = await planfixRequest<{ id: number }>(
-      `task/`,
-      postBody as unknown as Record<string, unknown>,
-    );
+    const result = await planfixRequest<{ id: number }>({
+      path: `task/`,
+      body: postBody as unknown as Record<string, unknown>,
+    });
     const taskId = result.id;
     const url = getTaskUrl(taskId);
 

--- a/src/tools/planfix_create_sell_task.ts
+++ b/src/tools/planfix_create_sell_task.ts
@@ -163,10 +163,10 @@ export async function createSellTask({
       });
     }
 
-    const result = await planfixRequest<{ id: number }>(
-      `task/`,
-      postBody as unknown as Record<string, unknown>,
-    );
+    const result = await planfixRequest<{ id: number }>({
+      path: `task/`,
+      body: postBody as unknown as Record<string, unknown>,
+    });
     const taskId = result.id;
     const url = getTaskUrl(taskId);
     return { taskId, url };

--- a/src/tools/planfix_create_task.integration.test.ts
+++ b/src/tools/planfix_create_task.integration.test.ts
@@ -34,20 +34,28 @@ describe("planfix_create_task tool prod", () => {
     expect(content).toMatchObject({
       taskId: expect.any(Number),
       clientId: expect.any(Number),
-      url: expect.stringMatching(new RegExp(`^https://${PLANFIX_ACCOUNT.replace(/\./g, '\\.')}\\.planfix\\.com/task/\\d+$`)),
-      clientUrl: expect.stringMatching(new RegExp(`^https://${PLANFIX_ACCOUNT.replace(/\./g, '\\.')}\\.planfix\\.com/contact/\\d+$`)),
+      url: expect.stringMatching(
+        new RegExp(
+          `^https://${PLANFIX_ACCOUNT.replace(/\./g, "\\.")}\\.planfix\\.com/task/\\d+$`,
+        ),
+      ),
+      clientUrl: expect.stringMatching(
+        new RegExp(
+          `^https://${PLANFIX_ACCOUNT.replace(/\./g, "\\.")}\\.planfix\\.com/contact/\\d+$`,
+        ),
+      ),
       assignees: {
         users: expect.arrayContaining([
           expect.objectContaining({
             id: expect.stringMatching(/^user:\d+$/),
-            name: expect.any(String)
-          })
+            name: expect.any(String),
+          }),
         ]),
-        groups: expect.any(Array)
+        groups: expect.any(Array),
       },
       firstName: expect.any(String),
       lastName: expect.any(String),
-      agencyId: expect.any(Number)
+      agencyId: expect.any(Number),
     });
 
     // Additional specific checks
@@ -55,7 +63,7 @@ describe("planfix_create_task tool prod", () => {
     expect(content.clientId).toBeGreaterThan(0);
     expect(content.agencyId).toBeGreaterThan(0);
     expect(content.assignees.users.length).toBeGreaterThan(0);
-    expect(content.firstName).toBe('Stanislav');
-    expect(content.lastName).toBe('Popov');
+    expect(content.firstName).toBe("Stanislav");
+    expect(content.lastName).toBe("Popov");
   });
 });

--- a/src/tools/planfix_create_task.integration.test.ts
+++ b/src/tools/planfix_create_task.integration.test.ts
@@ -10,7 +10,7 @@ describe("planfix_create_task tool prod", () => {
       phone: "+79222229531",
       agency: "Тестовое агентство",
       object: "Задача",
-      leadSource: "Zapier",
+      leadSource: "agent",
       title: "Test task title",
       telegram: "popstas",
       project: "Тестирование интеграции с Планфикс",

--- a/src/tools/planfix_create_task.ts
+++ b/src/tools/planfix_create_task.ts
@@ -1,12 +1,9 @@
 import { z } from "zod";
 import { getToolWithHandler } from "../helpers.js";
-import { getFieldDirectoryId } from "../lib/planfixObjects.js";
-import { searchDirectoryEntryById } from "../lib/planfixDirectory.js";
 import {
   addToLeadTask,
   AddToLeadTaskOutputSchema,
 } from "./planfix_add_to_lead_task.js";
-import { PLANFIX_FIELD_IDS } from "../config.js";
 
 export const PlanfixCreateTaskInputSchema = z.object({
   object: z.string().optional(),
@@ -34,18 +31,6 @@ export async function planfixCreateTask(
   const messageParts = [];
   if (leadSource) {
     messageParts.push(`Источник: ${leadSource}`);
-    if (args.object) {
-      const directoryId = await getFieldDirectoryId({
-        objectName: args.object,
-        fieldId: PLANFIX_FIELD_IDS.leadSource,
-      });
-      if (directoryId) {
-        const entryId = await searchDirectoryEntryById(directoryId, leadSource);
-        if (entryId) {
-          messageParts.push(`ID источника: ${entryId}`);
-        }
-      }
-    }
   }
   if (referral) {
     messageParts.push(`Реферал: ${referral}`);
@@ -59,6 +44,8 @@ export async function planfixCreateTask(
     message,
     managerEmail: args.managerEmail,
     project: args.project,
+    leadSource,
+    referral,
   });
 }
 

--- a/src/tools/planfix_create_task.ts
+++ b/src/tools/planfix_create_task.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { getToolWithHandler } from "../helpers.js";
 import { getFieldDirectoryId } from "../lib/planfixObjects.js";
+import { searchDirectoryEntryById } from "../lib/planfixDirectory.js";
 import {
   addToLeadTask,
   AddToLeadTaskOutputSchema,
@@ -39,7 +40,10 @@ export async function planfixCreateTask(
         fieldId: PLANFIX_FIELD_IDS.leadSource,
       });
       if (directoryId) {
-        // TODO: search_directory_entry(directoryId, leadSource)
+        const entryId = await searchDirectoryEntryById(directoryId, leadSource);
+        if (entryId) {
+          messageParts.push(`ID источника: ${entryId}`);
+        }
       }
     }
   }

--- a/src/tools/planfix_get_child_tasks.ts
+++ b/src/tools/planfix_get_child_tasks.ts
@@ -39,18 +39,21 @@ export async function getChildTasks({
   z.infer<typeof GetChildTasksOutputSchema>
 > {
   try {
-    const result = await planfixRequest(`task/list`, {
-      parent: { id: parentTaskId },
-      pageSize: 100,
-      offset: 0,
-      fields: ["id", "name", "description", "assignees", "status"].join(","),
-      filters: [
-        {
-          type: 73,
-          operator: "eq",
-          value: parentTaskId,
-        },
-      ],
+    const result = await planfixRequest({
+      path: `task/list`,
+      body: {
+        parent: { id: parentTaskId },
+        pageSize: 100,
+        offset: 0,
+        fields: ["id", "name", "description", "assignees", "status"].join(","),
+        filters: [
+          {
+            type: 73,
+            operator: "eq",
+            value: parentTaskId,
+          },
+        ],
+      },
     });
 
     const data = result as {

--- a/src/tools/planfix_get_report_fields.ts
+++ b/src/tools/planfix_get_report_fields.ts
@@ -47,11 +47,11 @@ export async function getReportFields({
   z.infer<typeof GetReportFieldsOutputSchema>
 > {
   try {
-    const result = await planfixRequest<ReportFieldsResponse>(
-      `report/${reportId}`,
-      { fields: "id,name,fields" },
-      "GET",
-    );
+    const result = await planfixRequest<ReportFieldsResponse>({
+      path: `report/${reportId}`,
+      body: { fields: "id,name,fields" },
+      method: "GET",
+    });
 
     if (result.result !== "success" || !result.repost) {
       throw new Error(result.message || "Failed to fetch report fields");

--- a/src/tools/planfix_reports_list.ts
+++ b/src/tools/planfix_reports_list.ts
@@ -27,10 +27,13 @@ export async function listReports(): Promise<
   z.infer<typeof ListReportsOutputSchema>
 > {
   try {
-    const result = (await planfixRequest(`report/list`, {
-      offset: 0,
-      pageSize: 100,
-      fields: "id,name",
+    const result = (await planfixRequest({
+      path: `report/list`,
+      body: {
+        offset: 0,
+        pageSize: 100,
+        fields: "id,name",
+      },
     })) as ReportListResponse;
 
     return {

--- a/src/tools/planfix_request.ts
+++ b/src/tools/planfix_request.ts
@@ -11,6 +11,7 @@ export const PlanfixRequestInputSchema = z.object({
     .record(z.unknown())
     .optional()
     .describe("Request body as planfix request object"),
+  cacheTime: z.number().optional().describe("Cache TTL in seconds"),
 });
 
 export const PlanfixRequestOutputSchema = z.record(z.unknown());
@@ -23,11 +24,12 @@ export async function planfixRequestHandler({
   method,
   path,
   body = {},
+  cacheTime,
 }: z.infer<typeof PlanfixRequestInputSchema>): Promise<
   z.infer<typeof PlanfixRequestOutputSchema>
 > {
   try {
-    const response = await planfixRequest(path, body, method);
+    const response = await planfixRequest({ path, body, method, cacheTime });
     return response as Record<string, unknown>;
   } catch (error) {
     const errorMessage =

--- a/src/tools/planfix_search_company.ts
+++ b/src/tools/planfix_search_company.ts
@@ -57,9 +57,12 @@ export async function planfixSearchCompany({
     try {
       const result = await planfixRequest<{
         contacts: Array<{ id: number; name: string }>;
-      }>(`contact/list`, {
-        ...postBody,
-        filters: currentFilters,
+      }>({
+        path: `contact/list`,
+        body: {
+          ...postBody,
+          filters: currentFilters,
+        },
       });
 
       if (result.contacts?.length > 0) {

--- a/src/tools/planfix_search_contact.ts
+++ b/src/tools/planfix_search_contact.ts
@@ -121,9 +121,12 @@ export async function planfixSearchContact({
     filter: FilterType,
   ): Promise<z.infer<typeof PlanfixSearchContactOutputSchema>> {
     try {
-      const result = (await planfixRequest("contact/list", {
-        ...postBody,
-        filters: [filter],
+      const result = (await planfixRequest({
+        path: "contact/list",
+        body: {
+          ...postBody,
+          filters: [filter],
+        },
       })) as {
         contacts?: Array<{ id: number; name?: string; lastname?: string }>;
       };

--- a/src/tools/planfix_search_directory.integration.test.ts
+++ b/src/tools/planfix_search_directory.integration.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { runTool } from "../helpers.js";
+
+// These tests require access to a real Planfix account
+
+describe("planfix_search_directory tool", () => {
+  it("searches directory by name", async () => {
+    const args = { name: "Источники лидов" };
+    const { valid, content } = await runTool<{
+      directoryId: number;
+      found: boolean;
+    }>("planfix_search_directory", args);
+    expect(valid).toBe(true);
+    expect(typeof content.directoryId).toBe("number");
+  });
+});

--- a/src/tools/planfix_search_directory.integration.test.ts
+++ b/src/tools/planfix_search_directory.integration.test.ts
@@ -5,12 +5,13 @@ import { runTool } from "../helpers.js";
 
 describe("planfix_search_directory tool", () => {
   it("searches directory by name", async () => {
-    const args = { name: "Источники лидов" };
+    const args = { name: "Источники задач" };
     const { valid, content } = await runTool<{
       directoryId: number;
       found: boolean;
     }>("planfix_search_directory", args);
     expect(valid).toBe(true);
     expect(typeof content.directoryId).toBe("number");
+    expect(content.directoryId).toBeGreaterThan(0);
   });
 });

--- a/src/tools/planfix_search_directory.ts
+++ b/src/tools/planfix_search_directory.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { getToolWithHandler, log } from "../helpers.js";
+import { searchDirectory } from "../lib/planfixDirectory.js";
+
+export const PlanfixSearchDirectoryInputSchema = z.object({
+  name: z.string(),
+});
+
+export const PlanfixSearchDirectoryOutputSchema = z.object({
+  directoryId: z.number(),
+  name: z.string().optional(),
+  found: z.boolean(),
+  error: z.string().optional(),
+});
+
+export async function planfixSearchDirectory({
+  name,
+}: z.infer<typeof PlanfixSearchDirectoryInputSchema>): Promise<
+  z.infer<typeof PlanfixSearchDirectoryOutputSchema>
+> {
+  try {
+    const dir = await searchDirectory(name);
+    if (dir) {
+      return { directoryId: dir.id, name: dir.name, found: true };
+    }
+    return { directoryId: 0, found: false };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Unknown error";
+    log(`[planfixSearchDirectory] ${message}`);
+    return { directoryId: 0, error: message, found: false };
+  }
+}
+
+async function handler(args?: Record<string, unknown>) {
+  const parsed = PlanfixSearchDirectoryInputSchema.parse(args);
+  return planfixSearchDirectory(parsed);
+}
+
+export default getToolWithHandler({
+  name: "planfix_search_directory",
+  description: "Search for a Planfix directory by name",
+  inputSchema: PlanfixSearchDirectoryInputSchema,
+  outputSchema: PlanfixSearchDirectoryOutputSchema,
+  handler,
+});

--- a/src/tools/planfix_search_directory_entry.integration.test.ts
+++ b/src/tools/planfix_search_directory_entry.integration.test.ts
@@ -3,12 +3,13 @@ import { runTool } from "../helpers.js";
 
 describe("planfix_search_directory_entry tool", () => {
   it("searches directory entry by directory and entry name", async () => {
-    const args = { directory: "Источники лидов", entry: "Zapier" };
+    const args = { directory: "Источники задач", entry: "agent" };
     const { valid, content } = await runTool<{
       entryId: number;
       found: boolean;
     }>("planfix_search_directory_entry", args);
     expect(valid).toBe(true);
     expect(typeof content.entryId).toBe("number");
+    expect(content.entryId).toBeGreaterThan(0);
   });
 });

--- a/src/tools/planfix_search_directory_entry.integration.test.ts
+++ b/src/tools/planfix_search_directory_entry.integration.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { runTool } from "../helpers.js";
+
+describe("planfix_search_directory_entry tool", () => {
+  it("searches directory entry by directory and entry name", async () => {
+    const args = { directory: "Источники лидов", entry: "Zapier" };
+    const { valid, content } = await runTool<{
+      entryId: number;
+      found: boolean;
+    }>("planfix_search_directory_entry", args);
+    expect(valid).toBe(true);
+    expect(typeof content.entryId).toBe("number");
+  });
+});

--- a/src/tools/planfix_search_directory_entry.ts
+++ b/src/tools/planfix_search_directory_entry.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { getToolWithHandler, log } from "../helpers.js";
+import {
+  searchDirectory,
+  searchDirectoryEntryById,
+} from "../lib/planfixDirectory.js";
+
+export const PlanfixSearchDirectoryEntryInputSchema = z.object({
+  directory: z.string().describe("Directory name"),
+  entry: z.string().describe("Entry name"),
+});
+
+export const PlanfixSearchDirectoryEntryOutputSchema = z.object({
+  entryId: z.number(),
+  found: z.boolean(),
+  error: z.string().optional(),
+});
+
+export async function planfixSearchDirectoryEntry({
+  directory,
+  entry,
+}: z.infer<typeof PlanfixSearchDirectoryEntryInputSchema>): Promise<
+  z.infer<typeof PlanfixSearchDirectoryEntryOutputSchema>
+> {
+  try {
+    const dir = await searchDirectory(directory);
+    if (!dir) {
+      return { entryId: 0, found: false, error: "Directory not found" };
+    }
+    const entryId = await searchDirectoryEntryById(dir.id, entry);
+    if (entryId) {
+      return { entryId, found: true };
+    }
+    return { entryId: 0, found: false };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Unknown error";
+    log(`[planfixSearchDirectoryEntry] ${message}`);
+    return { entryId: 0, found: false, error: message };
+  }
+}
+
+async function handler(args?: Record<string, unknown>) {
+  const parsed = PlanfixSearchDirectoryEntryInputSchema.parse(args);
+  return planfixSearchDirectoryEntry(parsed);
+}
+
+export default getToolWithHandler({
+  name: "planfix_search_directory_entry",
+  description: "Search for directory entry id by directory name and entry name",
+  inputSchema: PlanfixSearchDirectoryEntryInputSchema,
+  outputSchema: PlanfixSearchDirectoryEntryOutputSchema,
+  handler,
+});

--- a/src/tools/planfix_search_manager.ts
+++ b/src/tools/planfix_search_manager.ts
@@ -43,7 +43,10 @@ export async function searchManager({
       ],
     };
 
-    const result = (await planfixRequest("user/list", postBody)) as {
+    const result = (await planfixRequest({
+      path: "user/list",
+      body: postBody,
+    })) as {
       users?: Array<{
         id: number;
         name?: string;

--- a/src/tools/planfix_search_project.ts
+++ b/src/tools/planfix_search_project.ts
@@ -33,7 +33,10 @@ export async function searchProject({
   try {
     const result = await planfixRequest<{
       projects?: Array<{ id: number; name: string }>;
-    }>("project/list", postBody);
+    }>({
+      path: "project/list",
+      body: postBody,
+    });
     if (result.projects?.[0]) {
       return {
         projectId: result.projects[0].id,

--- a/src/tools/planfix_search_task.ts
+++ b/src/tools/planfix_search_task.ts
@@ -66,9 +66,12 @@ export async function searchPlanfixTask({
     filtersArr: Array<Record<string, unknown>>,
   ): Promise<z.infer<typeof SearchPlanfixTaskOutputSchema>> {
     try {
-      const result = (await planfixRequest(`task/list`, {
-        ...postBody,
-        filters: [...filtersDefault, ...filtersArr],
+      const result = (await planfixRequest({
+        path: `task/list`,
+        body: {
+          ...postBody,
+          filters: [...filtersDefault, ...filtersArr],
+        },
       })) as {
         tasks?: Array<{
           id: number;

--- a/src/tools/planfix_update_contact.integration.test.ts
+++ b/src/tools/planfix_update_contact.integration.test.ts
@@ -7,9 +7,9 @@ describe("planfix_update_contact tool prod", () => {
     const args = {
       contactId: 11,
       email: "pop..stas@gmail.com",
-      telegram: 'popstas',
-      phone: '+79222229531',
-      name: 'Stanislav Popov',
+      telegram: "popstas",
+      phone: "+79222229531",
+      name: "Stanislav Popov",
     };
     const { valid, content } = await runTool<{ contactId: number }>(
       "planfix_update_contact",

--- a/src/tools/planfix_update_contact.test.ts
+++ b/src/tools/planfix_update_contact.test.ts
@@ -40,7 +40,8 @@ describe("planfix_update_contact tool", () => {
 
   const setupMocks = (customContact?: Partial<typeof mockContact>) => {
     mockPlanfixRequest.mockReset();
-    mockPlanfixRequest.mockImplementation(async (endpoint: string) => {
+    mockPlanfixRequest.mockImplementation(async (args: any) => {
+      const endpoint = args.path;
       if (endpoint.startsWith("contact/") && endpoint !== "contact/1") {
         throw new Error("Contact not found");
       }
@@ -60,14 +61,14 @@ describe("planfix_update_contact tool", () => {
     });
 
     expect(mockPlanfixRequest).toHaveBeenCalledTimes(2);
-    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(
-      1,
-      "contact/1",
-      { fields: "id,name,lastname,email,phones,customFieldData" },
-      "GET",
-    );
-    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(2, "contact/1", {
-      email: "new@example.com",
+    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(1, {
+      path: "contact/1",
+      body: { fields: "id,name,lastname,email,phones,customFieldData" },
+      method: "GET",
+    });
+    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(2, {
+      path: "contact/1",
+      body: { email: "new@example.com" },
     });
     expect(result.contactId).toBe(1);
     expect(result.url).toBe("https://example.com/contact/1");
@@ -99,9 +100,9 @@ describe("planfix_update_contact tool", () => {
     });
 
     expect(mockPlanfixRequest).toHaveBeenCalledTimes(2);
-    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(2, "contact/1", {
-      name: "John",
-      lastname: "Smith",
+    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(2, {
+      path: "contact/1",
+      body: { name: "John", lastname: "Smith" },
     });
     expect(result.contactId).toBe(1);
   });
@@ -128,16 +129,18 @@ describe("planfix_update_contact tool", () => {
     });
 
     // Verify the GET call
-    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(
-      1,
-      "contact/1",
-      { fields: "id,name,lastname,email,phones,customFieldData" },
-      "GET",
-    );
+    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(1, {
+      path: "contact/1",
+      body: { fields: "id,name,lastname,email,phones,customFieldData" },
+      method: "GET",
+    });
 
     // Verify the UPDATE call
-    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(2, "contact/1", {
-      customFieldData: [{ field: { id: 1001 }, value: "@new_username" }],
+    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(2, {
+      path: "contact/1",
+      body: {
+        customFieldData: [{ field: { id: 1001 }, value: "@new_username" }],
+      },
     });
 
     expect(mockPlanfixRequest).toHaveBeenCalledTimes(2);
@@ -163,11 +166,11 @@ describe("planfix_update_contact tool", () => {
 
     // Verify only GET call was made
     expect(mockPlanfixRequest).toHaveBeenCalledTimes(1);
-    expect(mockPlanfixRequest).toHaveBeenCalledWith(
-      "contact/1",
-      { fields: "id,name,lastname,email,phones,customFieldData" },
-      "GET",
-    );
+    expect(mockPlanfixRequest).toHaveBeenCalledWith({
+      path: "contact/1",
+      body: { fields: "id,name,lastname,email,phones,customFieldData" },
+      method: "GET",
+    });
 
     expect(result.contactId).toBe(1);
   });
@@ -184,8 +187,9 @@ describe("planfix_update_contact tool", () => {
     });
 
     expect(mockPlanfixRequest).toHaveBeenCalledTimes(2);
-    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(2, "contact/1", {
-      phones: [...mockContact.phones, { number: newPhone, type: 1 }],
+    expect(mockPlanfixRequest).toHaveBeenNthCalledWith(2, {
+      path: "contact/1",
+      body: { phones: [...mockContact.phones, { number: newPhone, type: 1 }] },
     });
     expect(result.contactId).toBe(1);
   });

--- a/src/tools/planfix_update_contact.ts
+++ b/src/tools/planfix_update_contact.ts
@@ -64,11 +64,11 @@ export async function updatePlanfixContact({
       : PLANFIX_FIELD_IDS.telegram
         ? `${fieldsBase},telegram`
         : fieldsBase;
-    const { contact } = await planfixRequest<{ contact: ContactResponse }>(
-      `contact/${contactId}`,
-      { fields },
-      "GET",
-    );
+    const { contact } = await planfixRequest<{ contact: ContactResponse }>({
+      path: `contact/${contactId}`,
+      body: { fields },
+      method: "GET",
+    });
 
     const postBody: Record<string, unknown> = {};
 
@@ -134,7 +134,7 @@ export async function updatePlanfixContact({
       return { contactId, url: getContactUrl(contactId) };
     }
 
-    await planfixRequest(`contact/${contactId}`, postBody);
+    await planfixRequest({ path: `contact/${contactId}`, body: postBody });
     return { contactId, url: getContactUrl(contactId) };
   } catch (error) {
     const errorMessage =

--- a/src/types/better-sqlite3.d.ts
+++ b/src/types/better-sqlite3.d.ts
@@ -1,0 +1,1 @@
+declare module "better-sqlite3";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
   },
   "include": [
     "src/**/*.ts",
-    "src/**/*.tsx"
+    "src/**/*.tsx",
+    "src/types/**/*.d.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- add sqlite cache provider and integrate with `planfixRequest`
- implement tools `planfix_search_directory` and `planfix_search_directory_entry`
- finalize lead source lookup in `planfix_create_task`
- update all existing calls to new `planfixRequest` signature
- document new tools in README
- add integration tests for new tools

## Testing
- `npm run format`
- `npm run test`
- `npm run lint src`
- `npm run test-full` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684886987b6c832c83450f503057aae6