### PR TITLE
Fix npm proxy setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This repository contains a Model Context Protocol (MCP) server written in TypeSc
 - Run `npm run test-full` before commit.
 - Run `npm run format` before commit.
 - Update `README.md` when tools change.
+- In the setup script, append `export NPM_CONFIG_LOGLEVEL=silent npm_config_http_proxy= npm_config_https_proxy` to `~/.bashrc` to suppress npm proxy warnings.
 
 ## Development commands
 


### PR DESCRIPTION
## Summary
- document global npm proxy cleanup in `AGENTS.md`
- revert npm script env hacks and remove `.npmrc`

## Testing
- `npm install` *(fails: ECONNRESET)*


------
https://chatgpt.com/codex/tasks/task_e_68487f3f50c4832c863c919286d65c15