### PR TITLE
Implement task title and description changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,10 @@ const objects = await planfixClient.post('object/list', {
 
 ### Task Management
 
-- `searchPlanfixTask`: Search for tasks by name and client ID
+- `searchPlanfixTask`: Search for tasks by title and client ID
 - `createSellTask`: Create a new sell task with template
 - `createLeadTask`: Create a new lead task
+- `addToLeadTask`: Create or update a lead task with contact details
 - `createTask`: Create a task using text fields
 - `createComment`: Add a comment to a task
 - `getChildTasks`: Retrieve all child tasks of a parent task

--- a/src/tools/planfix_add_to_lead_task.integration.test.ts
+++ b/src/tools/planfix_add_to_lead_task.integration.test.ts
@@ -10,8 +10,8 @@ describe("planfix_add_to_lead_task tool", () => {
       phone: "+79222229531",
       telegram: "@popstas",
       email: "pop.stas@gmail.com",
-      header: "Test Lead via Automated Test",
-      message: "This is a test message for adding a lead task.",
+      title: "Test Lead via Automated Test",
+      description: "This is a test message for adding a lead task.",
       // managerEmail: 'optional_manager@example.com', // Optional: add if specific manager assignment needs testing
     };
 

--- a/src/tools/planfix_add_to_lead_task.ts
+++ b/src/tools/planfix_add_to_lead_task.ts
@@ -10,8 +10,8 @@ import { searchManager } from "./planfix_search_manager.js";
 import { searchPlanfixTask } from "./planfix_search_task.js";
 
 export const AddToLeadTaskInputSchema = UserDataInputSchema.extend({
-  header: z.string(),
-  message: z.string(),
+  title: z.string().optional(),
+  description: z.string(),
   managerEmail: z.string().optional(),
   project: z.string().optional(),
 });
@@ -51,9 +51,10 @@ export const AddToLeadTaskOutputSchema = z.object({
 function generateDescription(
   userData: z.infer<typeof UserDataInputSchema>,
   eventData: {
-    header?: string;
-    message?: string;
+    title?: string;
+    description?: string;
   },
+  taskTitle?: string,
 ): string {
   // Simple userData labels for Russian output
   const userDataLabels: Record<string, string> = {
@@ -62,24 +63,37 @@ function generateDescription(
     email: "Email",
     telegram: "Telegram",
   };
-  if (eventData?.header) {
-    return [
-      eventData.header,
-      "",
-      eventData.message ? eventData.message : "",
-    ].join("\n");
+
+  const lines: string[] = [];
+  if (eventData?.title && eventData.title !== taskTitle) {
+    lines.push(eventData.title);
+    lines.push("");
   }
-  if (!userData) {
-    return `Заявка от ${new Date().toLocaleString()}`;
+
+  if (eventData?.description) {
+    lines.push(eventData.description);
   }
-  const lines = [];
-  for (const key of Object.keys(userData)) {
-    if (userData[key as keyof typeof userData] && userDataLabels[key]) {
-      lines.push(
-        `${userDataLabels[key]}: ${userData[key as keyof typeof userData]}`,
-      );
+
+  const userLines = [] as string[];
+  if (userData) {
+    for (const key of Object.keys(userData)) {
+      if (userData[key as keyof typeof userData] && userDataLabels[key]) {
+        userLines.push(
+          `${userDataLabels[key]}: ${userData[key as keyof typeof userData]}`,
+        );
+      }
     }
   }
+
+  if (userLines.length) {
+    if (lines.length) lines.push("");
+    lines.push(...userLines);
+  }
+
+  if (!lines.length) {
+    return `Заявка от ${new Date().toLocaleString()}`;
+  }
+
   return lines.join("\n");
 }
 
@@ -95,8 +109,8 @@ export async function addToLeadTask({
   email,
   telegram,
   company,
-  header,
-  message,
+  title,
+  description,
   managerEmail,
   project,
 }: z.infer<typeof AddToLeadTaskInputSchema>): Promise<
@@ -115,7 +129,7 @@ export async function addToLeadTask({
   }
 
   const userData = { name, nameTranslated, phone, email, telegram, company };
-  const eventData = { header, message };
+  const eventData = { title, description };
   // Main logic
 
   try {
@@ -138,10 +152,19 @@ export async function addToLeadTask({
     let { taskId, clientId, url, clientUrl, assignees } = searchResult;
     // Variables that won't be reassigned
     const { firstName, lastName, agencyId } = searchResult;
-    const taskNameTemplate = "{clientName} - работа с клиентом";
+    const taskTitleTemplate = "{clientName} - работа с клиентом";
+    const finalTaskTitle = title
+      ? title
+      : replaceTemplateVars(taskTitleTemplate, {
+          clientName: userData.name,
+        });
 
-    const description = generateDescription(userData, eventData);
-    if (!description) {
+    const descriptionText = generateDescription(
+      userData,
+      eventData,
+      finalTaskTitle,
+    );
+    if (!descriptionText) {
       // console.log('[leadToTask] No description to send, skip create client or task');
       return { taskId, clientId, url, clientUrl };
     }
@@ -162,9 +185,7 @@ export async function addToLeadTask({
     if (clientId && !taskId && userData.name && userData.name.includes(" ")) {
       // console.log('[leadToTask] Searching for task by name...');
       const result = await searchPlanfixTask({
-        taskName: replaceTemplateVars(taskNameTemplate, {
-          clientName: userData.name,
-        }),
+        taskTitle: finalTaskTitle,
       });
       taskId = result.taskId || 0;
       assignees = result.assignees;
@@ -179,10 +200,8 @@ export async function addToLeadTask({
         managerId = managerResult.managerId;
       }
       const createLeadTaskResult = await createLeadTask({
-        name: replaceTemplateVars(taskNameTemplate, {
-          clientName: userData.name,
-        }),
-        description,
+        name: finalTaskTitle,
+        description: descriptionText,
         clientId,
         managerId: managerId ?? undefined,
         agencyId,
@@ -200,7 +219,7 @@ export async function addToLeadTask({
       // console.log('[leadToTask] Creating comment in found task...');
       const commentResult = await createComment({
         taskId,
-        description,
+        description: descriptionText,
         recipients: assignees,
       });
       if (commentResult.commentId) {

--- a/src/tools/planfix_create_task.test.ts
+++ b/src/tools/planfix_create_task.test.ts
@@ -31,7 +31,7 @@ describe("planfix_create_task", () => {
       expect.objectContaining({
         name: args.name,
         phone: args.phone,
-        header: args.title,
+        title: args.title,
       }),
     );
     expect(res.taskId).toBe(3);

--- a/src/tools/planfix_create_task.ts
+++ b/src/tools/planfix_create_task.ts
@@ -29,7 +29,6 @@ export async function planfixCreateTask(
 ): Promise<z.infer<typeof PlanfixCreateTaskOutputSchema>> {
   const { agency, referral, leadSource, title, ...userData } = args;
 
-  const header = title;
   const messageParts = [];
   if (leadSource) {
     messageParts.push(`Источник: ${leadSource}`);
@@ -46,13 +45,13 @@ export async function planfixCreateTask(
   if (referral) {
     messageParts.push(`Реферал: ${referral}`);
   }
-  const message = messageParts.join("\n");
+  const description = messageParts.join("\n");
 
   return await addToLeadTask({
     ...userData,
     company: agency,
-    header,
-    message,
+    title,
+    description,
     managerEmail: args.managerEmail,
     project: args.project,
   });

--- a/src/tools/planfix_search_task.integration.test.ts
+++ b/src/tools/planfix_search_task.integration.test.ts
@@ -4,7 +4,7 @@ import { runTool } from "../helpers.js";
 describe("planfix_search_task tool", () => {
   it('searches task by name="Корягин Егор - работа с клиентом" and returns task details', async () => {
     const args = {
-      taskName: "Корягин Егор - работа с клиентом",
+      taskTitle: "Корягин Егор - работа с клиентом",
     };
     const { valid, content } = await runTool<{
       taskId: number;
@@ -37,7 +37,7 @@ describe("planfix_search_task tool", () => {
 
   it("returns found: false when no task is found", async () => {
     const args = {
-      taskName: "Nonexistent Task Name 12345",
+      taskTitle: "Nonexistent Task Name 12345",
     };
     const { valid, content } = await runTool<{ found: boolean }>(
       "planfix_search_task",

--- a/src/tools/planfix_search_task.ts
+++ b/src/tools/planfix_search_task.ts
@@ -3,7 +3,7 @@ import { PLANFIX_FIELD_IDS } from "../config.js";
 import { getTaskUrl, getToolWithHandler, planfixRequest } from "../helpers.js";
 
 export const SearchPlanfixTaskInputSchema = z.object({
-  taskName: z.string().optional(),
+  taskTitle: z.string().optional(),
   clientId: z.number().optional(),
 });
 
@@ -22,10 +22,10 @@ interface Assignee {
 }
 
 export async function searchPlanfixTask({
-  taskName,
+  taskTitle,
   clientId,
 }: {
-  taskName?: string;
+  taskTitle?: string;
   clientId?: number;
 }): Promise<z.infer<typeof SearchPlanfixTaskOutputSchema>> {
   let taskId: number | undefined = undefined;
@@ -58,7 +58,7 @@ export async function searchPlanfixTask({
     byName: {
       type: 8,
       operator: "equal",
-      value: taskName,
+      value: taskTitle,
     },
   };
 
@@ -106,7 +106,7 @@ export async function searchPlanfixTask({
       taskId = result.taskId;
       assignees = result.assignees;
     }
-    if (!taskId && taskName) {
+    if (!taskId && taskTitle) {
       const result = await searchWithFilter([
         filters.byName /*, filters.byLastDays*/,
       ]);
@@ -142,7 +142,7 @@ async function handler(
 
 export const planfixSearchTaskTool = getToolWithHandler({
   name: "planfix_search_task",
-  description: "Search for a task in Planfix by name or client ID",
+  description: "Search for a task in Planfix by title or client ID",
   inputSchema: SearchPlanfixTaskInputSchema,
   outputSchema: SearchPlanfixTaskOutputSchema,
   handler,


### PR DESCRIPTION
## Summary
- rename `header` to `title` and `message` to `description` for lead task tools
- add `taskTitle` usage in search and creation helpers
- update description generator and related logic
- adjust tests and documentation

## Testing
- `npm run test-full` *(fails: PASS Waiting for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_684a9bd1f1a0832c8ecaa3aa077e9afe