### PR TITLE
Add planfix_update_lead_task tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ const objects = await planfixClient.post('object/list', {
 - `createTask`: Create a task using text fields
 - `createComment`: Add a comment to a task
 - `getChildTasks`: Retrieve all child tasks of a parent task
+- `updateLeadTask`: Update an existing lead task
 
 ### Directory Management
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import planfix_search_manager from "./tools/planfix_search_manager.js";
 import planfix_search_project from "./tools/planfix_search_project.js";
 import planfix_search_task from "./tools/planfix_search_task.js";
 import planfix_update_contact from "./tools/planfix_update_contact.js";
+import planfix_update_lead_task from "./tools/planfix_update_lead_task.js";
 
 log("Starting Planfix MCP Server");
 
@@ -52,6 +53,7 @@ const TOOLS: ToolWithHandler[] = [
   planfix_search_project,
   planfix_search_task,
   planfix_update_contact,
+  planfix_update_lead_task,
 ];
 
 const server = new Server(

--- a/src/tools/planfix_update_lead_task.test.ts
+++ b/src/tools/planfix_update_lead_task.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("../config.js", () => ({
+  PLANFIX_DRY_RUN: false,
+  PLANFIX_FIELD_IDS: {
+    manager: 1,
+    agency: 2,
+    leadSource: 3,
+    tags: 4,
+  },
+}));
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return {
+    ...actual,
+    planfixRequest: vi.fn(),
+    getTaskUrl: (id: number) => `https://example.com/task/${id}`,
+  };
+});
+
+vi.mock("./planfix_search_project.js", () => ({
+  searchProject: vi.fn().mockResolvedValue({ projectId: 10, found: true }),
+}));
+
+vi.mock("../lib/planfixObjects.js", () => ({
+  getFieldDirectoryId: vi.fn().mockResolvedValue(100),
+}));
+
+vi.mock("../lib/planfixDirectory.js", () => ({
+  createDirectoryEntry: vi.fn().mockResolvedValue(5),
+  searchDirectoryEntryById: vi.fn().mockResolvedValue(5),
+  getDirectoryFields: vi.fn().mockResolvedValue([{ id: 1 }]),
+}));
+
+import { planfixRequest } from "../helpers.js";
+
+const mockPlanfixRequest = vi.mocked(planfixRequest);
+
+describe("planfix_update_lead_task", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates lead task fields", async () => {
+    mockPlanfixRequest.mockResolvedValueOnce({});
+    const { updateLeadTask } = await import("./planfix_update_lead_task.js");
+
+    const result = await updateLeadTask({
+      taskId: 1,
+      name: "New",
+      description: "Desc",
+      managerId: 2,
+      agencyId: 3,
+      project: "Proj",
+      leadSource: "Site",
+      tags: ["tag"],
+    });
+
+    expect(mockPlanfixRequest).toHaveBeenCalledWith({
+      path: "task/1",
+      body: expect.any(Object),
+    });
+    expect(result.taskId).toBe(1);
+    expect(result.url).toBe("https://example.com/task/1");
+  });
+
+  it("handles dry run", async () => {
+    const original = await import("../config.js");
+    vi.resetModules();
+    vi.doMock("../config.js", () => ({
+      ...original,
+      PLANFIX_DRY_RUN: true,
+    }));
+    const { updateLeadTask: updateDry } = await import(
+      "./planfix_update_lead_task.js"
+    );
+    const res = await updateDry({ taskId: 2 });
+    expect(res.taskId).toBe(2);
+    expect(mockPlanfixRequest).not.toHaveBeenCalled();
+    vi.resetModules();
+  });
+});

--- a/src/tools/planfix_update_lead_task.ts
+++ b/src/tools/planfix_update_lead_task.ts
@@ -1,0 +1,168 @@
+import { z } from "zod";
+import { PLANFIX_DRY_RUN, PLANFIX_FIELD_IDS } from "../config.js";
+import {
+  getTaskUrl,
+  getToolWithHandler,
+  log,
+  planfixRequest,
+} from "../helpers.js";
+import type { CustomFieldDataType } from "../types.js";
+import { searchProject } from "./planfix_search_project.js";
+import { getFieldDirectoryId } from "../lib/planfixObjects.js";
+import {
+  createDirectoryEntry,
+  searchDirectoryEntryById,
+  getDirectoryFields,
+} from "../lib/planfixDirectory.js";
+
+export const UpdateLeadTaskInputSchema = z.object({
+  taskId: z.number(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  managerId: z.number().optional(),
+  agencyId: z.number().optional(),
+  project: z.string().optional(),
+  leadSource: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+export const UpdateLeadTaskOutputSchema = z.object({
+  taskId: z.number(),
+  url: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export async function updateLeadTask({
+  taskId,
+  name,
+  description,
+  managerId,
+  agencyId,
+  project,
+  leadSource,
+  tags,
+}: z.infer<typeof UpdateLeadTaskInputSchema>): Promise<
+  z.infer<typeof UpdateLeadTaskOutputSchema>
+> {
+  const TEMPLATE_ID = Number(process.env.PLANFIX_LEAD_TEMPLATE_ID);
+  const postBody: Record<string, unknown> = {};
+  const customFieldData: CustomFieldDataType[] = [];
+
+  if (name !== undefined) {
+    postBody.name = name;
+  }
+
+  if (description !== undefined) {
+    postBody.description = description.replace(/\n/g, "<br>");
+  }
+
+  if (managerId) {
+    customFieldData.push({
+      field: { id: PLANFIX_FIELD_IDS.manager },
+      value: { id: managerId },
+    });
+  }
+
+  if (agencyId) {
+    customFieldData.push({
+      field: { id: PLANFIX_FIELD_IDS.agency },
+      value: { id: agencyId },
+    });
+  }
+
+  if (leadSource) {
+    const directoryId = await getFieldDirectoryId({
+      objectId: TEMPLATE_ID,
+      fieldId: PLANFIX_FIELD_IDS.leadSource,
+    });
+    if (directoryId) {
+      const directoryFields = await getDirectoryFields(directoryId);
+      const directoryFieldId = directoryFields?.[0]?.id || 0;
+      const entryId = await searchDirectoryEntryById(
+        directoryId,
+        directoryFieldId,
+        leadSource,
+      );
+      if (entryId) {
+        customFieldData.push({
+          field: { id: PLANFIX_FIELD_IDS.leadSource },
+          value: { id: entryId },
+        });
+      }
+    }
+  }
+
+  if (tags?.length && PLANFIX_FIELD_IDS.tags && !PLANFIX_DRY_RUN) {
+    const directoryId = await getFieldDirectoryId({
+      objectId: TEMPLATE_ID,
+      fieldId: PLANFIX_FIELD_IDS.tags,
+    });
+    if (directoryId) {
+      const directoryFields = await getDirectoryFields(directoryId);
+      const directoryFieldId = directoryFields?.[0]?.id || 0;
+      const tagIds: number[] = [];
+      for (const tag of tags) {
+        let id = await searchDirectoryEntryById(
+          directoryId,
+          directoryFieldId,
+          tag,
+        );
+        if (!id) {
+          id = await createDirectoryEntry(directoryId, directoryFieldId, tag);
+        }
+        if (id) tagIds.push(id);
+      }
+      if (tagIds.length) {
+        customFieldData.push({
+          field: { id: PLANFIX_FIELD_IDS.tags },
+          value: tagIds.map((id) => ({ id })),
+        });
+      }
+    }
+  }
+
+  if (customFieldData.length) {
+    postBody.customFieldData = customFieldData;
+  }
+
+  if (project) {
+    const projectResult = await searchProject({ name: project });
+    if (projectResult.found) {
+      postBody.project = { id: projectResult.projectId };
+    } else if (description !== undefined) {
+      postBody.description = `${postBody.description || ""}<br>Проект: ${project}`;
+    }
+  }
+
+  try {
+    if (PLANFIX_DRY_RUN) {
+      log(`[DRY RUN] Would update lead task ${taskId}`);
+      return { taskId, url: getTaskUrl(taskId) };
+    }
+
+    await planfixRequest({ path: `task/${taskId}`, body: postBody });
+    return { taskId, url: getTaskUrl(taskId) };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    log(`[updateLeadTask] Error: ${errorMessage}`);
+    return { taskId: 0, error: errorMessage };
+  }
+}
+
+async function handler(
+  args?: Record<string, unknown>,
+): Promise<z.infer<typeof UpdateLeadTaskOutputSchema>> {
+  const parsedArgs = UpdateLeadTaskInputSchema.parse(args);
+  return updateLeadTask(parsedArgs);
+}
+
+export const planfixUpdateLeadTaskTool = getToolWithHandler({
+  name: "planfix_update_lead_task",
+  description: "Update a lead task in Planfix",
+  inputSchema: UpdateLeadTaskInputSchema,
+  outputSchema: UpdateLeadTaskOutputSchema,
+  handler,
+});
+
+export default planfixUpdateLeadTaskTool;


### PR DESCRIPTION
## Summary
- add `planfix_update_lead_task` tool to update lead tasks
- document new tool in README
- export the tool in `index.ts`
- unit tests for the new tool

## Testing
- `npm run format`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_685453e48fac832c97f723debe2a5ae8