### PR TITLE
Add SSE server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ PLANFIX_FIELD_ID_TAGS=131 \
 npx @popstas/planfix-mcp-server
 ```
 
+To run the server over Server-Sent Events (SSE), use the `planfix-mcp-server-sse` command:
+
+```sh
+PLANFIX_ACCOUNT=yourcompany \
+PLANFIX_TOKEN=your-api-token \
+planfix-mcp-server-sse
+```
+
 ### Using the Planfix Client
 
 The Planfix client provides a convenient way to interact with the Planfix API directly from the command line.

--- a/package.json
+++ b/package.json
@@ -5,13 +5,18 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
-  "bin": "./dist/index.js",
+  "bin": {
+    "planfix-mcp-server": "./dist/index.js",
+    "planfix-mcp-server-sse": "./dist/sse-server.js"
+  },
   "files": [
     "dist"
   ],
   "scripts": {
     "start": "node dist/index.js",
+    "sse": "node dist/sse-server.js",
     "dev": "tsx src/index.ts",
+    "dev:sse": "tsx src/sse-server.ts",
     "build": "tsc --project tsconfig.json",
     "clean": "rimraf dist",
     "lint": "eslint",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,111 +1,11 @@
 #!/usr/bin/env node
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { createPlanfixServer } from "./server.js";
 import { log } from "./helpers.js";
-import { ToolWithHandler } from "./types.js";
 
-import planfix_add_to_lead_task from "./tools/planfix_add_to_lead_task.js";
-import planfix_create_comment from "./tools/planfix_create_comment.js";
-import planfix_create_contact from "./tools/planfix_create_contact.js";
-import planfix_create_lead_task from "./tools/planfix_create_lead_task.js";
-import planfix_create_sell_task from "./tools/planfix_create_sell_task.js";
-import planfix_create_task from "./tools/planfix_create_task.js";
-import planfix_get_child_tasks from "./tools/planfix_get_child_tasks.js";
-import planfix_get_report_fields from "./tools/planfix_get_report_fields.js";
-import planfix_reports_list from "./tools/planfix_reports_list.js";
-import planfix_request from "./tools/planfix_request.js";
-import planfix_run_report from "./tools/planfix_run_report.js";
-import planfix_search_company from "./tools/planfix_search_company.js";
-import planfix_search_contact from "./tools/planfix_search_contact.js";
-import planfix_search_directory from "./tools/planfix_search_directory.js";
-import planfix_search_directory_entry from "./tools/planfix_search_directory_entry.js";
-import planfix_search_lead_task from "./tools/planfix_search_lead_task.js";
-import planfix_search_manager from "./tools/planfix_search_manager.js";
-import planfix_search_project from "./tools/planfix_search_project.js";
-import planfix_search_task from "./tools/planfix_search_task.js";
-import planfix_update_contact from "./tools/planfix_update_contact.js";
-import planfix_update_lead_task from "./tools/planfix_update_lead_task.js";
+log("Starting Planfix MCP Server (stdio mode)");
 
-log("Starting Planfix MCP Server");
-
-const TOOLS: ToolWithHandler[] = [
-  planfix_add_to_lead_task,
-  planfix_create_comment,
-  planfix_create_contact,
-  planfix_create_lead_task,
-  planfix_create_sell_task,
-  planfix_create_task,
-  planfix_get_child_tasks,
-  planfix_get_report_fields,
-  planfix_reports_list,
-  planfix_request,
-  planfix_run_report,
-  planfix_search_company,
-  planfix_search_contact,
-  planfix_search_directory,
-  planfix_search_directory_entry,
-  planfix_search_lead_task,
-  planfix_search_manager,
-  planfix_search_project,
-  planfix_search_task,
-  planfix_update_contact,
-  planfix_update_lead_task,
-];
-
-const server = new Server(
-  {
-    name: "planfix-mcp-server",
-    version: "1.0.0",
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  },
-);
-
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return { tools: TOOLS };
-});
-
-interface AnswerContent {
-  type: string;
-  text: string;
-}
-
-interface AnswerJson<T = unknown> {
-  content: AnswerContent[];
-  structuredContent: T;
-}
-
-function getAnswerJson<T = unknown>(data: T): AnswerJson<T> {
-  return {
-    structuredContent: data,
-    content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
-  };
-}
-
-// @ts-expect-error - The SDK's type definitions are too strict for our use case
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-  log(`Received tool call: ${name}`);
-  try {
-    const tool = TOOLS.find((tool) => tool.name === name);
-    if (!tool?.handler) {
-      return getAnswerJson({ error: `Handler not found for tool: ${name}` });
-    }
-    return getAnswerJson(await tool.handler(args));
-  } catch (error) {
-    console.error(`Error calling tool ${name}:`, error);
-    return getAnswerJson({
-      error: error instanceof Error ? error.message : "Unknown error",
-    });
-  }
-});
+const server = createPlanfixServer();
 
 async function main(): Promise<void> {
   const transport = new StdioServerTransport();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,108 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { log } from "./helpers.js";
+import { ToolWithHandler } from "./types.js";
+
+import planfix_add_to_lead_task from "./tools/planfix_add_to_lead_task.js";
+import planfix_create_comment from "./tools/planfix_create_comment.js";
+import planfix_create_contact from "./tools/planfix_create_contact.js";
+import planfix_create_lead_task from "./tools/planfix_create_lead_task.js";
+import planfix_create_sell_task from "./tools/planfix_create_sell_task.js";
+import planfix_create_task from "./tools/planfix_create_task.js";
+import planfix_get_child_tasks from "./tools/planfix_get_child_tasks.js";
+import planfix_get_report_fields from "./tools/planfix_get_report_fields.js";
+import planfix_reports_list from "./tools/planfix_reports_list.js";
+import planfix_request from "./tools/planfix_request.js";
+import planfix_run_report from "./tools/planfix_run_report.js";
+import planfix_search_company from "./tools/planfix_search_company.js";
+import planfix_search_contact from "./tools/planfix_search_contact.js";
+import planfix_search_directory from "./tools/planfix_search_directory.js";
+import planfix_search_directory_entry from "./tools/planfix_search_directory_entry.js";
+import planfix_search_lead_task from "./tools/planfix_search_lead_task.js";
+import planfix_search_manager from "./tools/planfix_search_manager.js";
+import planfix_search_project from "./tools/planfix_search_project.js";
+import planfix_search_task from "./tools/planfix_search_task.js";
+import planfix_update_contact from "./tools/planfix_update_contact.js";
+import planfix_update_lead_task from "./tools/planfix_update_lead_task.js";
+
+export const TOOLS: ToolWithHandler[] = [
+  planfix_add_to_lead_task,
+  planfix_create_comment,
+  planfix_create_contact,
+  planfix_create_lead_task,
+  planfix_create_sell_task,
+  planfix_create_task,
+  planfix_get_child_tasks,
+  planfix_get_report_fields,
+  planfix_reports_list,
+  planfix_request,
+  planfix_run_report,
+  planfix_search_company,
+  planfix_search_contact,
+  planfix_search_directory,
+  planfix_search_directory_entry,
+  planfix_search_lead_task,
+  planfix_search_manager,
+  planfix_search_project,
+  planfix_search_task,
+  planfix_update_contact,
+  planfix_update_lead_task,
+];
+
+export function createPlanfixServer(): Server {
+  const server = new Server(
+    {
+      name: "planfix-mcp-server",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools: TOOLS };
+  });
+
+  interface AnswerContent {
+    type: string;
+    text: string;
+  }
+
+  interface AnswerJson<T = unknown> {
+    content: AnswerContent[];
+    structuredContent: T;
+  }
+
+  function getAnswerJson<T = unknown>(data: T): AnswerJson<T> {
+    return {
+      structuredContent: data,
+      content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+    };
+  }
+
+  // @ts-expect-error - The SDK's type definitions are too strict for our use case
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    log(`Received tool call: ${name}`);
+    try {
+      const tool = TOOLS.find((t) => t.name === name);
+      if (!tool?.handler) {
+        return getAnswerJson({ error: `Handler not found for tool: ${name}` });
+      }
+      return getAnswerJson(await tool.handler(args));
+    } catch (error) {
+      console.error(`Error calling tool ${name}:`, error);
+      return getAnswerJson({
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  });
+
+  return server;
+}

--- a/src/sse-server.ts
+++ b/src/sse-server.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import http from "node:http";
+import { URL } from "node:url";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { createPlanfixServer } from "./server.js";
+import { log } from "./helpers.js";
+
+log("Starting Planfix MCP Server (SSE mode)");
+
+const server = createPlanfixServer();
+const transports: Record<string, SSEServerTransport> = {};
+
+const httpServer = http.createServer(async (req, res) => {
+  if (!req.url) return res.end();
+  const url = new URL(req.url, "http://localhost");
+
+  if (req.method === "GET" && url.pathname === "/sse") {
+    const transport = new SSEServerTransport("/messages", res);
+    transports[transport.sessionId] = transport;
+    res.on("close", () => {
+      delete transports[transport.sessionId];
+    });
+    await server.connect(transport);
+  } else if (req.method === "POST" && url.pathname === "/messages") {
+    const sessionId = url.searchParams.get("sessionId") || "";
+    const transport = transports[sessionId];
+    if (transport) {
+      await transport.handlePostMessage(req, res);
+    } else {
+      res.statusCode = 400;
+      res.end("No transport found for sessionId");
+    }
+  } else {
+    res.statusCode = 404;
+    res.end();
+  }
+});
+
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+httpServer.listen(port, () => {
+  console.log(`SSE server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- refactor MCP server setup into `createPlanfixServer`
- add new SSE entry point using Node http server
- expose new CLI command `planfix-mcp-server-sse`
- document SSE usage

## Testing
- `npm run test-full`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6856ec2d0694832c8b2aaf642a5f9fc8