### PR TITLE
Add pipeline field for Planfix tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The server requires the following environment variables for Planfix API access:
 - `PLANFIX_FIELD_ID_AGENCY` – Custom field ID for agency
 - `PLANFIX_FIELD_ID_LEAD_SOURCE` – Custom field ID for lead source
 - `PLANFIX_FIELD_ID_LEAD_SOURCE_VALUE` – Value ID for default lead source
+- `PLANFIX_FIELD_ID_PIPELINE` – Custom field ID for pipeline
 - `PLANFIX_FIELD_ID_TAGS` – Custom field ID for task tags
   - Missing tag names will be added automatically to the directory
 
@@ -82,7 +83,8 @@ PLANFIX_FIELD_ID_MANAGER=127 \
 PLANFIX_FIELD_ID_AGENCY=128 \
 PLANFIX_FIELD_ID_LEAD_SOURCE=129 \
 PLANFIX_FIELD_ID_LEAD_SOURCE_VALUE=130 \
-PLANFIX_FIELD_ID_TAGS=131 \
+PLANFIX_FIELD_ID_PIPELINE=131 \
+PLANFIX_FIELD_ID_TAGS=132 \
 npx @popstas/planfix-mcp-server
 ```
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ export const PLANFIX_FIELD_IDS = {
   manager: Number(process.env.PLANFIX_FIELD_ID_MANAGER),
   agency: Number(process.env.PLANFIX_FIELD_ID_AGENCY),
   leadSource: Number(process.env.PLANFIX_FIELD_ID_LEAD_SOURCE),
+  pipeline: Number(process.env.PLANFIX_FIELD_ID_PIPELINE),
   serviceMatrix: Number(process.env.PLANFIX_FIELD_ID_SERVICE_MATRIX),
   tags: Number(process.env.PLANFIX_FIELD_ID_TAGS),
 };

--- a/src/tools/planfix_add_to_lead_task.ts
+++ b/src/tools/planfix_add_to_lead_task.ts
@@ -22,6 +22,7 @@ export const AddToLeadTaskInputSchema = UserDataInputSchema.extend({
   managerEmail: z.string().optional(),
   project: z.string().optional(),
   leadSource: z.string().optional(),
+  pipeline: z.string().optional(),
   referral: z.string().optional(),
   tags: z.array(z.string()).optional(),
 });
@@ -126,6 +127,7 @@ export async function addToLeadTask({
   managerEmail,
   project,
   leadSource,
+  pipeline,
   referral,
   tags,
 }: z.infer<typeof AddToLeadTaskInputSchema>): Promise<
@@ -236,6 +238,7 @@ export async function addToLeadTask({
         agencyId,
         project,
         leadSource,
+        pipeline,
         referral,
         tags,
       });

--- a/src/tools/planfix_create_lead_task.test.ts
+++ b/src/tools/planfix_create_lead_task.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("../config.js", () => ({
+  PLANFIX_DRY_RUN: false,
+  PLANFIX_FIELD_IDS: {
+    client: 1,
+    manager: 2,
+    agency: 3,
+    leadSource: 4,
+    pipeline: 5,
+    tags: 6,
+  },
+}));
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return {
+    ...actual,
+    planfixRequest: vi.fn().mockResolvedValue({ id: 1 }),
+    getTaskUrl: (id: number) => `https://example.com/task/${id}`,
+  };
+});
+
+vi.mock("./planfix_search_project.js", () => ({
+  searchProject: vi.fn().mockResolvedValue({ projectId: 10, found: true }),
+}));
+
+vi.mock("../lib/planfixObjects.js", () => ({
+  getFieldDirectoryId: vi.fn().mockResolvedValue(100),
+}));
+
+vi.mock("../lib/planfixDirectory.js", () => ({
+  createDirectoryEntry: vi.fn().mockResolvedValue(5),
+  searchDirectoryEntryById: vi.fn().mockResolvedValue(5),
+  getDirectoryFields: vi.fn().mockResolvedValue([{ id: 1 }]),
+}));
+
+import { planfixRequest } from "../helpers.js";
+
+const mockPlanfixRequest = vi.mocked(planfixRequest);
+
+describe("planfix_create_lead_task", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates task with pipeline", async () => {
+    const { createLeadTask } = await import("./planfix_create_lead_task.js");
+
+    const result = await createLeadTask({
+      name: "Test",
+      description: "Desc",
+      clientId: 1,
+      managerId: 2,
+      agencyId: 3,
+      project: "Proj",
+      leadSource: "Site",
+      pipeline: "Main",
+      tags: ["tag"],
+    });
+
+    expect(mockPlanfixRequest).toHaveBeenCalledWith({
+      path: "task/",
+      body: expect.objectContaining({
+        customFieldData: expect.arrayContaining([
+          expect.objectContaining({
+            field: { id: 5 },
+            value: { id: 5 },
+          }),
+        ]),
+      }),
+    });
+    expect(result.taskId).toBe(1);
+  });
+});

--- a/src/tools/planfix_create_task.test.ts
+++ b/src/tools/planfix_create_task.test.ts
@@ -23,6 +23,7 @@ describe("planfix_create_task", () => {
       agency: "Agency",
       referral: "Ref",
       leadSource: "site",
+      pipeline: "Main",
     };
 
     const res = await planfixCreateTask(args);
@@ -32,6 +33,7 @@ describe("planfix_create_task", () => {
         name: args.name,
         phone: args.phone,
         title: args.title,
+        pipeline: args.pipeline,
       }),
     );
     expect(res.taskId).toBe(3);

--- a/src/tools/planfix_create_task.ts
+++ b/src/tools/planfix_create_task.ts
@@ -15,6 +15,7 @@ export const PlanfixCreateTaskInputSchema = z.object({
   email: z.string().optional(),
   telegram: z.string().optional(),
   leadSource: z.string().optional(),
+  pipeline: z.string().optional(),
   project: z.string().optional(),
   agency: z.string().optional(),
   referral: z.string().optional(),
@@ -25,14 +26,24 @@ export const PlanfixCreateTaskInputSchema = z.object({
 export const PlanfixCreateTaskOutputSchema = AddToLeadTaskOutputSchema;
 
 export async function planfixCreateTask(
-  args: z.infer<typeof PlanfixCreateTaskInputSchema>
+  args: z.infer<typeof PlanfixCreateTaskInputSchema>,
 ): Promise<z.infer<typeof PlanfixCreateTaskOutputSchema>> {
-  const { agency, referral, leadSource, title, managerEmail, ...userData } =
-    args;
+  const {
+    agency,
+    referral,
+    leadSource,
+    pipeline,
+    title,
+    managerEmail,
+    ...userData
+  } = args;
 
   const messageParts = [];
   if (leadSource) {
     messageParts.push(`Источник: ${leadSource}`);
+  }
+  if (pipeline) {
+    messageParts.push(`Воронка: ${pipeline}`);
   }
   if (referral) {
     messageParts.push(`Реферал: ${referral}`);
@@ -53,6 +64,7 @@ export async function planfixCreateTask(
     managerEmail,
     project: args.project,
     leadSource,
+    pipeline,
     referral,
     tags: args.tags,
   });


### PR DESCRIPTION
## Summary
- support new optional `pipeline` field in Planfix task tools
- handle pipeline directory entries when creating lead tasks
- document `PLANFIX_FIELD_ID_PIPELINE` environment variable
- add tests for pipeline support

## Testing
- `npm run typecheck`
- `npm run test`
- `npm run lint src`


------
https://chatgpt.com/codex/tasks/task_e_68593ff900d4832c8c262b7908e88cc0