### PR TITLE
feat: improve lead task update

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ const objects = await planfixClient.post('object/list', {
 - `createTask`: Create a task using text fields
 - `createComment`: Add a comment to a task
 - `getChildTasks`: Retrieve all child tasks of a parent task
-- `updateLeadTask`: Update an existing lead task
+- `updateLeadTask`: Update an existing lead task (only empty fields are updated unless `forceUpdate` is true)
 
 ### Directory Management
 

--- a/src/tools/planfix_create_task_3.integration.test.ts
+++ b/src/tools/planfix_create_task_3.integration.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { PLANFIX_ACCOUNT } from "../config.js";
+import { runTool } from "../helpers.js";
+
+describe("planfix_create_task tool prod", () => {
+  it("creates task", async () => {
+    const args = {
+      title: "Сделка 79688854424",
+      name: "Дмитрий",
+      phone: "79222222222",
+      leadSource: "Входящий звонок",
+      tags: ["Пропущенный звонок", "79222222222"],
+      description:
+        "\nТеги:\nПропущенный звонок, 79222222222\n\nПоля:\nПереход в &quot;Новый лид&quot;: 1750162698\nroistat: Sipuni\nАктуальный этап (Основная воронка): Отказ\nИсточник: Входящий звонок\nПричина отказа: Черный список / не целевой\nКвалификация: Нецелевой\nПереход в &quot;Отказ&quot;: 1750164638\n\nURL: https://example.ru/leads/detail/36920019",
+      managerEmail: "popstas@gmail.com",
+      pipeline: "Основная воронка",
+    };
+    const { valid, content } = await runTool<{
+      taskId: number;
+      clientId: number;
+      url: string;
+      clientUrl: string;
+      assignees: {
+        users: Array<{ id: string; name: string }>;
+        groups: any[];
+      };
+      firstName: string;
+      lastName: string;
+      agencyId: number;
+    }>("planfix_create_task", args);
+    expect(valid).toBe(true);
+
+    // Check response structure and types
+    expect(content).toMatchObject({
+      taskId: expect.any(Number),
+      clientId: expect.any(Number),
+      url: expect.stringMatching(
+        new RegExp(
+          `^https://${PLANFIX_ACCOUNT.replace(/\./g, "\\.")}\\.planfix\\.com/task/\\d+$`
+        )
+      ),
+      clientUrl: expect.stringMatching(
+        new RegExp(
+          `^https://${PLANFIX_ACCOUNT.replace(/\./g, "\\.")}\\.planfix\\.com/contact/\\d+$`
+        )
+      ),
+      assignees: {
+        users: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.stringMatching(/^user:\d+$/),
+            name: expect.any(String),
+          }),
+        ]),
+        groups: expect.any(Array),
+      },
+      firstName: expect.any(String),
+      lastName: expect.any(String),
+      agencyId: expect.any(Number),
+    });
+
+    // Additional specific checks
+    expect(content.taskId).toBeGreaterThan(0);
+    expect(content.clientId).toBeGreaterThan(0);
+    expect(content.agencyId).toBeGreaterThan(0);
+    expect(content.assignees.users.length).toBeGreaterThan(0);
+    expect(content.firstName).toBe("Контакт");
+    expect(content.lastName).toBe("79660620181");
+  });
+});

--- a/src/tools/planfix_update_lead_task.integration.test.ts
+++ b/src/tools/planfix_update_lead_task.integration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { PLANFIX_ACCOUNT } from "../config.js";
+import { runTool } from "../helpers.js";
+
+describe("planfix_update_lead_task tool prod", () => {
+  it("updates task", async () => {
+    const args = {
+      taskId: 5704,
+      description: "",
+      title: "Сделка 79688854424 upd",
+      name: "Контакт 79660620181",
+      phone: "79222222222",
+      leadSource: "Входящий звонок",
+      pipeline: "Основная воронка",
+      tags: ["+7 966 032-88-03", "Пропущенный звонок"],
+      forceUpdate: true,
+    };
+    const { valid, content } = await runTool<{
+      taskId: number;
+      url: string;
+      assignees: {
+        users: Array<{ id: string; name: string }>;
+        groups: any[];
+      };
+      firstName: string;
+      lastName: string;
+      agencyId: number;
+    }>("planfix_update_lead_task", args);
+    expect(valid).toBe(true);
+
+    // Check response structure and types
+    expect(content).toMatchObject({
+      taskId: expect.any(Number),
+      url: expect.stringMatching(
+        new RegExp(
+          `^https://${PLANFIX_ACCOUNT.replace(/\./g, "\\.")}\\.planfix\\.com/task/\\d+$`
+        )
+      ),
+      assignees: {
+        users: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.stringMatching(/^user:\d+$/),
+            name: expect.any(String),
+          }),
+        ]),
+        groups: expect.any(Array),
+      },
+      firstName: expect.any(String),
+      lastName: expect.any(String),
+      agencyId: expect.any(Number),
+    });
+
+    // Additional specific checks
+    expect(content.taskId).toBeGreaterThan(0);
+    expect(content.agencyId).toBeGreaterThan(0);
+    expect(content.assignees.users.length).toBeGreaterThan(0);
+    expect(content.firstName).toBe("Контакт");
+    expect(content.lastName).toBe("79660620181");
+  });
+});

--- a/src/tools/planfix_update_lead_task.test.ts
+++ b/src/tools/planfix_update_lead_task.test.ts
@@ -70,7 +70,7 @@ describe("planfix_update_lead_task", () => {
       expect.arrayContaining([
         expect.objectContaining({
           path: "task/1",
-          body: { fields: "id,project,assignees,customFieldData" },
+          body: { fields: "id,name,description,1,2,3,4" },
           method: "GET",
         }),
         expect.objectContaining({ path: "task/1" }),

--- a/src/tools/planfix_update_lead_task.ts
+++ b/src/tools/planfix_update_lead_task.ts
@@ -16,9 +16,18 @@ import {
 } from "../lib/planfixDirectory.js";
 import { searchManager } from "./planfix_search_manager.js";
 import { LeadTaskBaseSchema } from "./schemas/leadTaskSchemas.js";
+import type { CustomFieldDataType } from "../types.js";
+
+interface TaskResponse {
+  id: number;
+  project?: { id: number };
+  assignees?: { users?: Array<{ id: string }> };
+  customFieldData?: CustomFieldDataType[];
+}
 
 export const UpdateLeadTaskInputSchema = LeadTaskBaseSchema.extend({
   taskId: z.number(),
+  forceUpdate: z.boolean().optional(),
 });
 
 export const UpdateLeadTaskOutputSchema = z.object({
@@ -39,6 +48,7 @@ export async function updateLeadTask({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   referral,
   tags,
+  forceUpdate,
 }: z.infer<typeof UpdateLeadTaskInputSchema>): Promise<
   z.infer<typeof UpdateLeadTaskOutputSchema>
 > {
@@ -47,119 +57,179 @@ export async function updateLeadTask({
     template: {
       id: TEMPLATE_ID,
     },
-    // name: name || "",
-    // description: description.replace(/\n/g, "<br>"),
     customFieldData: [],
   };
-
-  if (name) {
-    console.log("name is not updated");
-  }
-
-  if (description) {
-    console.log("description is not updated");
-  }
-
-  let managerId = 0;
-  if (managerEmail) {
-    const managerResult = await searchManager({ email: managerEmail });
-    managerId = managerResult.managerId;
-  }
-  if (managerId) {
-    if (PLANFIX_FIELD_IDS.manager) {
-      postBody.customFieldData.push({
-        field: { id: PLANFIX_FIELD_IDS.manager },
-        value: { id: managerId },
-      });
-    } else {
-      postBody.assignees = { users: [{ id: `user:${managerId}` }] };
-    }
-  }
-
-  if (project) {
-    const projectResult = await searchProject({ name: project });
-    if (projectResult.found) {
-      postBody.project = { id: projectResult.projectId };
-    }
-  }
-
-  if (leadSource) {
-    const directoryId = await getFieldDirectoryId({
-      objectId: TEMPLATE_ID,
-      fieldId: PLANFIX_FIELD_IDS.leadSource,
-    });
-    if (directoryId) {
-      const directoryFields = await getDirectoryFields(directoryId);
-      const directoryFieldId = directoryFields?.[0]?.id || 0;
-      const entryId = await searchDirectoryEntryById(
-        directoryId,
-        directoryFieldId,
-        leadSource
-      );
-      if (entryId) {
-        postBody.customFieldData.push({
-          field: { id: PLANFIX_FIELD_IDS.leadSource },
-          value: { id: entryId },
-        });
-      }
-    }
-  }
-
-  if (pipeline) {
-    const directoryId = await getFieldDirectoryId({
-      objectId: TEMPLATE_ID,
-      fieldId: PLANFIX_FIELD_IDS.pipeline,
-    });
-    if (directoryId) {
-      const directoryFields = await getDirectoryFields(directoryId);
-      const directoryFieldId = directoryFields?.[0]?.id || 0;
-      const entryId = await searchDirectoryEntryById(
-        directoryId,
-        directoryFieldId,
-        pipeline
-      );
-
-      if (entryId) {
-        postBody.customFieldData.push({
-          field: { id: PLANFIX_FIELD_IDS.pipeline },
-          value: { id: entryId },
-        });
-      }
-    }
-  }
-
-  if (tags?.length && PLANFIX_FIELD_IDS.tags && !PLANFIX_DRY_RUN) {
-    const directoryId = await getFieldDirectoryId({
-      objectId: TEMPLATE_ID,
-      fieldId: PLANFIX_FIELD_IDS.tags,
-    });
-    if (directoryId) {
-      const directoryFields = await getDirectoryFields(directoryId);
-      const directoryFieldId = directoryFields?.[0]?.id || 0;
-      const tagIds: number[] = [];
-      for (const tag of tags) {
-        let id = await searchDirectoryEntryById(
-          directoryId,
-          directoryFieldId,
-          tag
-        );
-        if (!id) {
-          id = await createDirectoryEntry(directoryId, directoryFieldId, tag);
-        }
-        if (id) tagIds.push(id);
-      }
-      if (tagIds.length) {
-        postBody.customFieldData.push({
-          field: { id: PLANFIX_FIELD_IDS.tags },
-          value: tagIds.map((id) => ({ id })),
-        });
-      }
-    }
-  }
 
   try {
     if (PLANFIX_DRY_RUN) {
       log(`[DRY RUN] Would update lead task ${taskId}`);
+      return { taskId, url: getTaskUrl(taskId) };
+    }
+
+    const fields = "id,project,assignees,customFieldData";
+    const { task } = await planfixRequest<{ task: TaskResponse }>({
+      path: `task/${taskId}`,
+      body: { fields },
+      method: "GET",
+    });
+
+    if (name) {
+      console.log("name is not updated");
+    }
+
+    if (description) {
+      console.log("description is not updated");
+    }
+
+    let managerId = 0;
+    if (managerEmail) {
+      const managerResult = await searchManager({ email: managerEmail });
+      managerId = managerResult.managerId;
+    }
+    if (managerId) {
+      if (PLANFIX_FIELD_IDS.manager) {
+        const managerField = task.customFieldData?.find(
+          (f) => f.field.id === PLANFIX_FIELD_IDS.manager,
+        );
+        const currentId =
+          managerField && typeof managerField.value === "object"
+            ? Number((managerField.value as { id: number }).id)
+            : 0;
+        if ((forceUpdate || !currentId) && managerId !== currentId) {
+          postBody.customFieldData.push({
+            field: { id: PLANFIX_FIELD_IDS.manager },
+            value: { id: managerId },
+          });
+        }
+      } else {
+        const currentUsers = task.assignees?.users || [];
+        const exists = currentUsers.some((u) => u.id === `user:${managerId}`);
+        if (forceUpdate || !exists) {
+          postBody.assignees = { users: [{ id: `user:${managerId}` }] };
+        }
+      }
+    }
+
+    if (project) {
+      const projectResult = await searchProject({ name: project });
+      if (projectResult.found) {
+        const currentProjectId = task.project?.id || 0;
+        if (
+          (forceUpdate || !currentProjectId) &&
+          projectResult.projectId !== currentProjectId
+        ) {
+          postBody.project = { id: projectResult.projectId };
+        }
+      }
+    }
+
+    if (leadSource) {
+      const directoryId = await getFieldDirectoryId({
+        objectId: TEMPLATE_ID,
+        fieldId: PLANFIX_FIELD_IDS.leadSource,
+      });
+      if (directoryId) {
+        const directoryFields = await getDirectoryFields(directoryId);
+        const directoryFieldId = directoryFields?.[0]?.id || 0;
+        const entryId = await searchDirectoryEntryById(
+          directoryId,
+          directoryFieldId,
+          leadSource,
+        );
+        const currentLeadSource = task.customFieldData?.find(
+          (f) => f.field.id === PLANFIX_FIELD_IDS.leadSource,
+        );
+        const currentId =
+          currentLeadSource && typeof currentLeadSource.value === "object"
+            ? Number((currentLeadSource.value as { id: number }).id)
+            : 0;
+        if (entryId && (forceUpdate || !currentId) && entryId !== currentId) {
+          postBody.customFieldData.push({
+            field: { id: PLANFIX_FIELD_IDS.leadSource },
+            value: { id: entryId },
+          });
+        }
+      }
+    }
+
+    if (pipeline) {
+      const directoryId = await getFieldDirectoryId({
+        objectId: TEMPLATE_ID,
+        fieldId: PLANFIX_FIELD_IDS.pipeline,
+      });
+      if (directoryId) {
+        const directoryFields = await getDirectoryFields(directoryId);
+        const directoryFieldId = directoryFields?.[0]?.id || 0;
+        const entryId = await searchDirectoryEntryById(
+          directoryId,
+          directoryFieldId,
+          pipeline,
+        );
+        const currentPipeline = task.customFieldData?.find(
+          (f) => f.field.id === PLANFIX_FIELD_IDS.pipeline,
+        );
+        const currentId =
+          currentPipeline && typeof currentPipeline.value === "object"
+            ? Number((currentPipeline.value as { id: number }).id)
+            : 0;
+        if (entryId && (forceUpdate || !currentId) && entryId !== currentId) {
+          postBody.customFieldData.push({
+            field: { id: PLANFIX_FIELD_IDS.pipeline },
+            value: { id: entryId },
+          });
+        }
+      }
+    }
+
+    if (tags?.length && PLANFIX_FIELD_IDS.tags && !PLANFIX_DRY_RUN) {
+      const directoryId = await getFieldDirectoryId({
+        objectId: TEMPLATE_ID,
+        fieldId: PLANFIX_FIELD_IDS.tags,
+      });
+      if (directoryId) {
+        const directoryFields = await getDirectoryFields(directoryId);
+        const directoryFieldId = directoryFields?.[0]?.id || 0;
+        const tagIds: number[] = [];
+        const tagsField = task.customFieldData?.find(
+          (f) => f.field.id === PLANFIX_FIELD_IDS.tags,
+        );
+        const hasTags =
+          Array.isArray(tagsField?.value) &&
+          (tagsField?.value as { id: number }[]).length > 0;
+        if (!forceUpdate && hasTags) {
+          // skip updating tags if already set
+        } else {
+          for (const tag of tags) {
+            let id = await searchDirectoryEntryById(
+              directoryId,
+              directoryFieldId,
+              tag,
+            );
+            if (!id) {
+              id = await createDirectoryEntry(
+                directoryId,
+                directoryFieldId,
+                tag,
+              );
+            }
+            if (id) tagIds.push(id);
+          }
+          if (tagIds.length) {
+            postBody.customFieldData.push({
+              field: { id: PLANFIX_FIELD_IDS.tags },
+              value: tagIds.map((id) => ({ id })),
+            });
+          }
+        }
+      }
+    }
+
+    const hasUpdates =
+      postBody.project ||
+      postBody.assignees ||
+      postBody.customFieldData.length > 0;
+
+    if (!hasUpdates) {
       return { taskId, url: getTaskUrl(taskId) };
     }
 
@@ -177,7 +247,7 @@ export async function updateLeadTask({
 }
 
 async function handler(
-  args?: Record<string, unknown>
+  args?: Record<string, unknown>,
 ): Promise<z.infer<typeof UpdateLeadTaskOutputSchema>> {
   const parsedArgs = UpdateLeadTaskInputSchema.parse(args);
   return updateLeadTask(parsedArgs);

--- a/src/tools/schemas/leadTaskSchemas.ts
+++ b/src/tools/schemas/leadTaskSchemas.ts
@@ -47,6 +47,7 @@ export const AddToLeadTaskOutputSchema = z.object({
 
 export const UpdateLeadTaskInputSchema = LeadTaskBaseSchema.extend({
   taskId: z.number(),
+  forceUpdate: z.boolean().optional(),
 });
 
 export const UpdateLeadTaskOutputSchema = z.object({


### PR DESCRIPTION
## Summary
- add `forceUpdate` option to updateLeadTask schemas
- update `updateLeadTask` logic to check existing values first
- adjust tests for new behavior
- document new option in README

## Testing
- `npm run typecheck`
- `npm run test`
- `npm run lint src`

------
https://chatgpt.com/codex/tasks/task_e_68596f45b690832ca8841d25274f33cd