### PR TITLE
Add cache debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The server requires the following environment variables for Planfix API access:
 npx @modelcontextprotocol/inspector node d:/projects/expertizeme/planfix-mcp-server/dist/index.js
 ```
 
+### Logging
+
+Set `LOG_LEVEL=debug` to enable detailed cache logs. Logs are written to `data/mcp.log`.
+
 ## Example MCP Config (NPX)
 
 ```json

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import DatabaseConstructor from "better-sqlite3";
+import { debugLog } from "../helpers.js";
 
 export interface CacheProvider {
   get<T>(key: string): Promise<T | undefined>;
@@ -10,6 +11,7 @@ export class SqliteCache implements CacheProvider {
   private db: ReturnType<typeof DatabaseConstructor>;
   constructor(dbPath: string) {
     this.db = new DatabaseConstructor(dbPath);
+    debugLog(`[SqliteCache] db path: ${dbPath}`);
     this.db.exec(
       "CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value TEXT, expiresAt INTEGER)",
     );
@@ -18,20 +20,27 @@ export class SqliteCache implements CacheProvider {
     const row = this.db
       .prepare("SELECT value, expiresAt FROM cache WHERE key=?")
       .get(key) as { value: string; expiresAt: number } | undefined;
-    if (!row) return undefined;
+    if (!row) {
+      debugLog(`[SqliteCache] miss ${key}`);
+      return undefined;
+    }
     if (row.expiresAt && row.expiresAt < Date.now()) {
       this.db.prepare("DELETE FROM cache WHERE key=?").run(key);
+      debugLog(`[SqliteCache] expired ${key}`);
       return undefined;
     }
     try {
+      debugLog(`[SqliteCache] hit ${key}`);
       return JSON.parse(row.value) as T;
     } catch {
+      debugLog(`[SqliteCache] failed to parse ${key}`);
       return undefined;
     }
   }
   async set<T>(key: string, value: T, ttl: number = 3600): Promise<void> {
     const expiresAt = Date.now() + ttl * 1000;
     const valueStr = JSON.stringify(value);
+    debugLog(`[SqliteCache] set ${key}, ttl ${ttl}s`);
     this.db
       .prepare(
         "INSERT OR REPLACE INTO cache(key,value,expiresAt) VALUES(?,?,?)",
@@ -44,6 +53,7 @@ let provider: CacheProvider | undefined;
 export function getCacheProvider(): CacheProvider {
   if (!provider) {
     const dbPath = path.join(process.cwd(), "data", "planfix-cache.sqlite3");
+    debugLog(`[getCacheProvider] cache path: ${dbPath}`);
     provider = new SqliteCache(dbPath);
   }
   return provider;


### PR DESCRIPTION
## Summary
- add `debugLog` helper that writes to log when `LOG_LEVEL=debug`
- include debug information in `withCache` and sqlite cache provider
- note `LOG_LEVEL` usage in README

## Testing
- `npm run format`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_685af9eb48b8832ca8f87944f931acf8