### PR TITLE
Improve error messages for missing fields

### DIFF
--- a/src/lib/planfixCustomFields.ts
+++ b/src/lib/planfixCustomFields.ts
@@ -1,0 +1,27 @@
+import { log, planfixRequest } from "../helpers.js";
+
+export interface CustomFieldInfo {
+  id: number;
+  name: string;
+}
+
+/**
+ * Retrieve the name of a custom task field by its ID.
+ */
+export async function getTaskCustomFieldName(
+  fieldId: number,
+): Promise<string | undefined> {
+  try {
+    const result = await planfixRequest<{ customfields?: CustomFieldInfo[] }>({
+      path: `customfield/task`,
+      method: "GET",
+      body: { fields: "id,name" },
+      cacheTime: 3600,
+    });
+    const field = result.customfields?.find((f) => f.id === fieldId);
+    return field?.name;
+  } catch (error) {
+    log(`[getTaskCustomFieldName] ${(error as Error).message}`);
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- add helper to fetch task field names
- include field name when a required field error occurs
- test the custom field error message

## Testing
- `npm run format`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_685bcc142d58832cbe26cdcee88e8716