### PR TITLE
Add lib unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 This repository contains a Model Context Protocol (MCP) server written in TypeScript that integrates with the Planfix CRM REST API. The server exposes several tools located in `src/tools` which can be called by MCP clients.
 
+## Coverage improve rules
+- Run `npm test` and `npm run coverage-info` to check coverage, sorted by lines_uncovered.
+- Prefer less covered files.
+- Cover each function first.
+- Check `npm run coverage-info` in the end of each iteration, calculate coverage change.
+
 ## Rules before commit
 - Run `npm run test-full` before commit.
 - Run `npm run format` before commit.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:unit": "cross-env CI=1 npx vitest --exclude '**/*.integration.test.ts'",
     "test:integration": "cross-env CI=1 npx vitest integration",
     "test-full": "npm run typecheck && npm run test && npm run lint src",
+    "coverage-info": "tsx src/scripts/coverage-info.ts",
     "prepare-build": "npm run build && npm run test-full",
     "prepublishOnly": "npm run prepare-build",
     "mcp-cli": "mcp-inspector --cli npm run dev",

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { SqliteCache } from "./cache.js";
+
+function tmpDb(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cache-"));
+  return path.join(dir, "test.sqlite");
+}
+
+describe("SqliteCache", () => {
+  let dbPath: string;
+  beforeEach(() => {
+    dbPath = tmpDb();
+  });
+
+  it("stores and retrieves values", async () => {
+    const cache = new SqliteCache(dbPath);
+    await cache.set("key", { a: 1 });
+    const result = await cache.get<{ a: number }>("key");
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it("returns undefined for expired values", async () => {
+    const cache = new SqliteCache(dbPath);
+    await cache.set("exp", "v", 1);
+    await new Promise((r) => setTimeout(r, 1100));
+    const result = await cache.get("exp");
+    expect(result).toBeUndefined();
+  });
+
+  it("handles unparsable JSON gracefully", async () => {
+    const cache = new SqliteCache(dbPath);
+    // insert invalid json directly
+    const db: any = (cache as any).db;
+    db.prepare(
+      "INSERT OR REPLACE INTO cache(key,value,expiresAt) VALUES(?,?,?)",
+    ).run("bad", "notjson", Date.now() + 1000);
+    const result = await cache.get("bad");
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/lib/extendFiltersWithCustomFields.test.ts
+++ b/src/lib/extendFiltersWithCustomFields.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  extendFiltersWithCustomFields,
+  type PlanfixFilter,
+} from "./extendFiltersWithCustomFields.js";
+import { log } from "../helpers.js";
+import type { CustomField } from "./extendSchemaWithCustomFields.js";
+
+vi.mock("../helpers.js", () => ({ log: vi.fn() }));
+const mockedLog = vi.mocked(log);
+
+describe("extendFiltersWithCustomFields", () => {
+  beforeEach(() => {
+    mockedLog.mockClear();
+  });
+
+  it("adds filters for provided values", () => {
+    const fields: CustomField[] = [{ id: 1, argName: "name", type: "string" }];
+    const filters: PlanfixFilter[] = [];
+    extendFiltersWithCustomFields(filters, { name: "John" }, fields, "contact");
+    expect(filters).toEqual([
+      { type: 4101, field: 1, operator: "equal", value: "John" },
+    ]);
+  });
+
+  it("skips fields with empty values", () => {
+    const fields: CustomField[] = [{ id: 1, argName: "name", type: "string" }];
+    const filters: PlanfixFilter[] = [];
+    extendFiltersWithCustomFields(filters, {}, fields, "contact");
+    extendFiltersWithCustomFields(filters, { name: "" }, fields, "contact");
+    expect(filters.length).toBe(0);
+  });
+
+  it("logs unknown field types", () => {
+    const fields: CustomField[] = [
+      { id: 1, argName: "foo", type: "unknown" as any },
+    ];
+    const filters: PlanfixFilter[] = [];
+    extendFiltersWithCustomFields(filters, { foo: "bar" }, fields, "contact");
+    expect(mockedLog).toHaveBeenCalled();
+    expect(filters.length).toBe(0);
+  });
+});

--- a/src/lib/extendPostBodyWithCustomFields.test.ts
+++ b/src/lib/extendPostBodyWithCustomFields.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { extendPostBodyWithCustomFields } from "./extendPostBodyWithCustomFields.js";
+import type { CustomField } from "./extendSchemaWithCustomFields.js";
+import type { TaskResponse, ContactResponse } from "../types.js";
+
+describe("extendPostBodyWithCustomFields", () => {
+  const stringField: CustomField = { id: 1, argName: "name", type: "string" };
+  const enumField: CustomField = {
+    id: 2,
+    argName: "status",
+    type: "enum",
+    values: ["one", "two"],
+  };
+
+  it("adds custom field data from args", () => {
+    const body: Record<string, any> = {};
+    extendPostBodyWithCustomFields(body, { name: "A" }, [stringField]);
+    expect(body.customFieldData).toEqual([{ field: { id: 1 }, value: "A" }]);
+  });
+
+  it("uses default when arg missing", () => {
+    const body: Record<string, any> = {};
+    extendPostBodyWithCustomFields(body, {}, [
+      { ...stringField, default: "B" },
+    ]);
+    expect(body.customFieldData).toEqual([{ field: { id: 1 }, value: "B" }]);
+  });
+
+  it("skips when enum value unchanged and forceUpdate is false", () => {
+    const body: Record<string, any> = {};
+    const task: TaskResponse = {
+      id: 1,
+      customFieldData: [{ field: { id: 2 }, value: ["one"] }],
+    } as TaskResponse;
+    extendPostBodyWithCustomFields(body, { status: "one" }, [enumField], task);
+    expect(body.customFieldData).toBeUndefined();
+  });
+
+  it("updates when forceUpdate is true", () => {
+    const body: Record<string, any> = {};
+    const contact: ContactResponse = {
+      id: 1,
+      customFieldData: [{ field: { id: 2 }, value: ["one"] }],
+    } as ContactResponse;
+    extendPostBodyWithCustomFields(
+      body,
+      { status: "one" },
+      [enumField],
+      undefined,
+      contact,
+      true,
+    );
+    expect(body.customFieldData).toEqual([{ field: { id: 2 }, value: "one" }]);
+  });
+});

--- a/src/lib/planfixCustomFields.test.ts
+++ b/src/lib/planfixCustomFields.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getTaskCustomFieldName } from "./planfixCustomFields.js";
+import { planfixRequest, log } from "../helpers.js";
+
+vi.mock("../helpers.js", () => ({
+  planfixRequest: vi.fn(),
+  log: vi.fn(),
+}));
+
+const mockedRequest = vi.mocked(planfixRequest);
+const mockedLog = vi.mocked(log);
+
+describe("getTaskCustomFieldName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the field name when found", async () => {
+    mockedRequest.mockResolvedValueOnce({
+      customfields: [{ id: 1, name: "Field" }],
+    });
+    const name = await getTaskCustomFieldName(1);
+    expect(name).toBe("Field");
+    expect(mockedRequest).toHaveBeenCalledWith({
+      path: `customfield/task`,
+      method: "GET",
+      body: { fields: "id,name" },
+      cacheTime: 3600,
+    });
+  });
+
+  it("returns undefined when field not found", async () => {
+    mockedRequest.mockResolvedValueOnce({ customfields: [] });
+    const name = await getTaskCustomFieldName(2);
+    expect(name).toBeUndefined();
+  });
+
+  it("logs and returns undefined on error", async () => {
+    const err = new Error("fail");
+    mockedRequest.mockRejectedValueOnce(err);
+    const name = await getTaskCustomFieldName(1);
+    expect(name).toBeUndefined();
+    expect(mockedLog).toHaveBeenCalledWith(
+      `[getTaskCustomFieldName] ${err.message}`,
+    );
+  });
+});

--- a/src/scripts/coverage-info.ts
+++ b/src/scripts/coverage-info.ts
@@ -1,0 +1,97 @@
+import { readFileSync, existsSync } from 'fs';
+import path from 'path';
+
+interface CoverageSummary {
+  total: {
+    lines: {
+      total: number;
+      covered: number;
+      skipped: number;
+      pct: number;
+    };
+    statements: {
+      total: number;
+      covered: number;
+      skipped: number;
+      pct: number;
+    };
+    functions: {
+      total: number;
+      covered: number;
+      skipped: number;
+      pct: number;
+    };
+    branches: {
+      total: number;
+      covered: number;
+      skipped: number;
+      pct: number;
+    };
+  };
+  [filePath: string]: any;
+}
+
+export interface FileCoverageInfo {
+  path: string;
+  lines_total: number;
+  lines_covered: number;
+  lines_uncovered: number;
+  lines_coverage: number;
+  functions_total: number;
+  functions_covered: number;
+  functions_uncovered: number;
+  functions_coverage: number;
+}
+
+function toRelativePath(filePath: string): string {
+  return filePath.replace(process.cwd(), '').replace(/\\/g, '/');
+}
+
+export function parseCoverage(coveragePath = 'coverage/coverage-summary.json'): FileCoverageInfo[] {
+  const absolutePath = path.resolve(process.cwd(), coveragePath);
+  
+  if (!existsSync(absolutePath)) {
+    return [];
+  }
+
+  try {
+    const coverageData: CoverageSummary = JSON.parse(
+      readFileSync(absolutePath, 'utf-8')
+    );
+
+    return Object.entries(coverageData)
+      .filter(([key]) => key !== 'total')
+      .map(([filePath, fileCoverage]) => ({
+        path: toRelativePath(filePath),
+        lines_total: fileCoverage.lines.total,
+        lines_covered: fileCoverage.lines.covered,
+        lines_uncovered: fileCoverage.lines.total - fileCoverage.lines.covered,
+        lines_coverage: fileCoverage.lines.pct,
+        functions_total: fileCoverage.functions.total,
+        functions_covered: fileCoverage.functions.covered,
+        functions_uncovered: fileCoverage.functions.total - fileCoverage.functions.covered,
+        functions_coverage: fileCoverage.functions.pct,
+      }))
+      .sort((a, b) => b.lines_uncovered - a.lines_uncovered);
+  } catch (error) {
+    console.error('Error parsing coverage file:', error);
+    return [];
+  }
+}
+
+export function coverageInfo(coveragePath = 'coverage/coverage-summary.json'): void {
+  const coverage = parseCoverage(coveragePath);
+  console.log(JSON.stringify(coverage, null, 2));
+}
+
+// Convert file path to URL format for comparison
+function toFileUrl(filePath: string): string {
+  const pathName = path.resolve(filePath).replace(/\\/g, '/');
+  return `file://${pathName.startsWith('/') ? '' : '/'}${pathName}`;
+}
+
+// Run if this file is executed directly
+const currentFileUrl = toFileUrl(process.argv[1]);
+if (import.meta.url === currentFileUrl) {
+  coverageInfo();
+}


### PR DESCRIPTION
## Summary
- add test coverage for cache utility
- cover filter extension helper
- test post body custom field helper
- verify retrieving Planfix custom field names

## Testing
- `npm run test-full`
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e7e080ba4832c8695d4b3911e3e1f