### PR TITLE
Add unit tests for planfix_search_contact

### DIFF
--- a/src/lib/planfixObjects.test.ts
+++ b/src/lib/planfixObjects.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import yaml from "js-yaml";
+import {
+  getObjects,
+  getObjectsNames,
+  getFieldDirectoryId,
+} from "./planfixObjects.js";
+
+function tmpCache(data: any): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pfo-"));
+  const file = path.join(dir, "cache.yml");
+  fs.writeFileSync(file, yaml.dump(data));
+  return file;
+}
+
+describe("planfixObjects", () => {
+  it("returns objects from cache", async () => {
+    const objects = { Contact: { id: 1, name: "Contact" } };
+    const cache = tmpCache(objects);
+    const result = await getObjects(cache);
+    expect(result).toEqual(objects);
+  });
+
+  it("gets object names", async () => {
+    const cache = tmpCache({
+      A: { id: 1, name: "A" },
+      B: { id: 2, name: "B" },
+    });
+    const names = await getObjectsNames(cache);
+    expect(names).toEqual(expect.arrayContaining(["A", "B"]));
+  });
+
+  it("gets directory id by object and field names", async () => {
+    const cache = tmpCache({
+      Obj: {
+        id: 1,
+        name: "Obj",
+        customFieldData: [
+          { field: { name: "Field", directoryId: 777, id: 5 } },
+        ],
+      },
+    });
+    const id = await getFieldDirectoryId({
+      objectName: "Obj",
+      fieldName: "Field",
+      cachePath: cache,
+    });
+    expect(id).toBe(777);
+  });
+
+  it("falls back to object id", async () => {
+    const cache = tmpCache({
+      Obj: {
+        id: 42,
+        name: "Obj",
+        customFieldData: [
+          { field: { id: 5, directoryId: 333, name: "Other" } },
+        ],
+      },
+    });
+    const id = await getFieldDirectoryId({
+      objectId: 42,
+      fieldId: 5,
+      cachePath: cache,
+    });
+    expect(id).toBe(333);
+  });
+});

--- a/src/tools/planfix_search_contact.test.ts
+++ b/src/tools/planfix_search_contact.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../config.js", () => ({
+  PLANFIX_FIELD_IDS: {
+    telegram: 131,
+    telegramCustom: 0,
+  },
+}));
+
+vi.mock("../customFieldsConfig.js", () => ({
+  customFieldsConfig: { contactFields: [] },
+}));
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return {
+    ...actual,
+    planfixRequest: vi.fn(),
+    getContactUrl: (id: number) => `https://example.com/contact/${id}`,
+    log: vi.fn(),
+  };
+});
+
+import { planfixRequest } from "../helpers.js";
+import { planfixSearchContact } from "./planfix_search_contact.js";
+
+const mockPlanfixRequest = vi.mocked(planfixRequest);
+
+describe("planfixSearchContact", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns contact when found by email", async () => {
+    mockPlanfixRequest.mockResolvedValueOnce({
+      contacts: [{ id: 1, name: "John", lastname: "Doe" }],
+    });
+
+    const result = await planfixSearchContact({ email: "john@example.com" });
+
+    expect(mockPlanfixRequest).toHaveBeenCalledTimes(1);
+    const call = mockPlanfixRequest.mock.calls[0][0];
+    expect(call.path).toBe("contact/list");
+    const body = call.body as any;
+    expect(body.filters[0]).toMatchObject({
+      type: 4026,
+      value: "john@example.com",
+    });
+    expect(result).toEqual({
+      contactId: 1,
+      url: "https://example.com/contact/1",
+      firstName: "John",
+      lastName: "Doe",
+      found: true,
+    });
+  });
+
+  it("skips phone search when phone is invalid", async () => {
+    mockPlanfixRequest.mockResolvedValueOnce({
+      contacts: [{ id: 2, name: "Foo", lastname: "Bar" }],
+    });
+
+    const result = await planfixSearchContact({
+      phone: "@foo",
+      telegram: "foo",
+    });
+
+    expect(mockPlanfixRequest).toHaveBeenCalledTimes(1);
+    const call = mockPlanfixRequest.mock.calls[0][0];
+    // first call should be byTelegram filter
+    const body = call.body as any;
+    expect(body.filters[0]).toMatchObject({ value: "foo" });
+    expect(result.contactId).toBe(2);
+    expect(result.found).toBe(true);
+  });
+
+  it("handles API errors", async () => {
+    mockPlanfixRequest.mockRejectedValueOnce(new Error("API fail"));
+
+    const result = await planfixSearchContact({ email: "err@example.com" });
+
+    expect(mockPlanfixRequest).toHaveBeenCalledTimes(1);
+    expect(result.contactId).toBe(0);
+    expect(result.error).toBeUndefined();
+    expect(result.found).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add new unit test file for planfix_search_contact tool
- increase coverage on planfix_search_contact.ts

## Testing
- `npm run test-full`
- `npm run coverage-info`

------
https://chatgpt.com/codex/tasks/task_e_685e9201337c832c930e18c7c4577d31