### PR TITLE
Improve test coverage

### DIFF
--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "path";
+
+vi.mock("fs/promises", () => ({
+  default: {
+    mkdir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  },
+}));
+
+import fsp from "fs/promises";
+import { withCache, isValidToolResponse } from "./helpers.js";
+
+const mockReadFile = vi.mocked(fsp.readFile);
+const mockWriteFile = vi.mocked(fsp.writeFile);
+const mockMkdir = vi.mocked(fsp.mkdir);
+
+describe("withCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns cached data if cache is valid", async () => {
+    const cached = { data: { value: 1 }, expiresAt: Date.now() + 1000 };
+    mockReadFile.mockResolvedValueOnce(JSON.stringify(cached));
+    const dataFn = vi.fn();
+
+    const res = await withCache("cache", dataFn);
+
+    expect(res).toEqual(cached.data);
+    expect(dataFn).not.toHaveBeenCalled();
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("generates data and writes cache when missing", async () => {
+    mockReadFile.mockRejectedValueOnce(new Error("miss"));
+    const dataFn = vi.fn().mockResolvedValue({ ok: true });
+
+    const res = await withCache("new", dataFn, 10);
+
+    expect(dataFn).toHaveBeenCalledTimes(1);
+    expect(mockMkdir).toHaveBeenCalled();
+    expect(mockWriteFile).toHaveBeenCalled();
+    const writeArgs = mockWriteFile.mock.calls[0];
+    expect(writeArgs[0]).toContain(path.join("data", "cache", "new.json"));
+    const written = JSON.parse(writeArgs[1] as string);
+    expect(written.data).toEqual({ ok: true });
+    expect(res).toEqual({ ok: true });
+  });
+});
+
+describe("isValidToolResponse", () => {
+  it("validates correct shape", () => {
+    const obj = { content: [{ text: "hi" }], structuredContent: {} };
+    expect(isValidToolResponse(obj)).toBe(true);
+  });
+
+  it("fails for invalid value", () => {
+    expect(isValidToolResponse({})).toBe(false);
+  });
+});

--- a/src/tools/planfix_request.test.ts
+++ b/src/tools/planfix_request.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return { ...actual, planfixRequest: vi.fn() };
+});
+
+import { planfixRequest } from "../helpers.js";
+import { planfixRequestHandler } from "./planfix_request.js";
+
+const mockPlanfixRequest = vi.mocked(planfixRequest);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("planfixRequestHandler", () => {
+  it("returns response when request succeeds", async () => {
+    mockPlanfixRequest.mockResolvedValueOnce({ ok: true });
+    const res = await planfixRequestHandler({
+      method: "POST",
+      path: "task/list",
+      body: { a: 1 },
+    });
+    expect(res).toEqual({ ok: true });
+    expect(mockPlanfixRequest).toHaveBeenCalledWith({
+      path: "task/list",
+      body: { a: 1 },
+      method: "POST",
+      cacheTime: undefined,
+    });
+  });
+
+  it("returns error object on failure", async () => {
+    mockPlanfixRequest.mockRejectedValueOnce(new Error("fail"));
+    const res = await planfixRequestHandler({ method: "GET", path: "bad" });
+    expect(res).toEqual({
+      success: false,
+      error: "fail",
+      path: "bad",
+      method: "GET",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for withCache and tool response validation
- add unit tests for planfix_request tool handler

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_685e9d0de7d8832ca01edc7ebf31cea5