### PR TITLE
Add tests for PlanfixClient

### DIFF
--- a/src/lib/planfix-client.test.ts
+++ b/src/lib/planfix-client.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PlanfixClient } from "./planfix-client.js";
+import { planfixRequest } from "../helpers.js";
+
+vi.mock("../helpers.js", () => ({
+  planfixRequest: vi.fn(),
+}));
+
+const mockedRequest = vi.mocked(planfixRequest);
+
+describe("PlanfixClient", () => {
+  let client: PlanfixClient;
+  beforeEach(() => {
+    client = new PlanfixClient();
+    vi.clearAllMocks();
+  });
+
+  it("sends GET requests with params", async () => {
+    mockedRequest.mockResolvedValueOnce({ ok: true });
+    const result = await client.get("path", { a: 1 });
+    expect(mockedRequest).toHaveBeenCalledWith({
+      path: "path",
+      body: { a: 1 },
+      method: "GET",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("sends POST requests", async () => {
+    mockedRequest.mockResolvedValueOnce({ success: true });
+    const data = { foo: "bar" };
+    const result = await client.post("items", data);
+    expect(mockedRequest).toHaveBeenCalledWith({
+      path: "items",
+      body: data,
+      method: "POST",
+    });
+    expect(result).toEqual({ success: true });
+  });
+
+  it("sends other methods using POST and _method", async () => {
+    mockedRequest.mockResolvedValueOnce({ patched: true });
+    const result = await client.patch("item/1", { foo: "bar" });
+    expect(mockedRequest).toHaveBeenCalledWith({
+      path: "item/1",
+      body: { foo: "bar", _method: "PATCH" },
+      method: "POST",
+    });
+    expect(result).toEqual({ patched: true });
+  });
+
+  it("throws error when request fails", async () => {
+    const error = new Error("oops");
+    mockedRequest.mockRejectedValueOnce(error);
+    await expect(client.get("x")).rejects.toThrow(error);
+  });
+});

--- a/src/tools/planfix_search_company.test.ts
+++ b/src/tools/planfix_search_company.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return {
+    ...actual,
+    planfixRequest: vi.fn(),
+    getContactUrl: (id: number) => `https://example.com/contact/${id}`,
+    log: vi.fn(),
+  };
+});
+
+import { planfixRequest } from "../helpers.js";
+import { planfixSearchCompany } from "./planfix_search_company.js";
+
+const mockPlanfixRequest = vi.mocked(planfixRequest);
+
+describe("planfixSearchCompany", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns company when found by name", async () => {
+    mockPlanfixRequest.mockResolvedValueOnce({
+      contacts: [{ id: 5, name: "Acme" }],
+    });
+
+    const result = (await planfixSearchCompany({ name: "Acme" })) as any;
+
+    expect(mockPlanfixRequest).toHaveBeenCalledTimes(1);
+    const call = mockPlanfixRequest.mock.calls[0][0];
+    expect(call.path).toBe("contact/list");
+    const body = call.body as any;
+    expect(body.filters).toContainEqual({
+      type: 4001,
+      operator: "equal",
+      value: "Acme",
+    });
+    expect(result).toEqual({
+      contactId: 5,
+      url: "https://example.com/contact/5",
+      name: "Acme",
+      error: undefined,
+    });
+  });
+
+  it("returns not found when company absent", async () => {
+    mockPlanfixRequest.mockResolvedValueOnce({ contacts: [] });
+
+    const result = (await planfixSearchCompany({ name: "None" })) as any;
+
+    expect(mockPlanfixRequest).toHaveBeenCalledTimes(1);
+    expect(result.contactId).toBe(0);
+    expect(result.name).toBeUndefined();
+  });
+
+  it("handles API errors", async () => {
+    mockPlanfixRequest.mockRejectedValueOnce(new Error("API fail"));
+
+    const result = (await planfixSearchCompany({ name: "Boom" })) as any;
+
+    expect(mockPlanfixRequest).toHaveBeenCalledTimes(1);
+    expect(result.contactId).toBe(0);
+    expect(result.error).toBe("API fail");
+  });
+});


### PR DESCRIPTION
## Summary
- add `planfix-client.test.ts` covering request behaviour

## Testing
- `npm run test`
- `npm run test-full`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685ec1acb80c832c95224a65fab8c7c8