### PR TITLE
Add tests for planfixRequest

### DIFF
--- a/src/planfixRequest.func.test.ts
+++ b/src/planfixRequest.func.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const cacheMap = new Map<string, any>();
+const getMock = vi.fn(async (key: string) => cacheMap.get(key));
+const setMock = vi.fn(async (key: string, value: any) => {
+  cacheMap.set(key, value);
+});
+const getCacheProvider = vi.fn(() => ({ get: getMock, set: setMock }));
+
+vi.mock("./lib/cache.js", () => ({ getCacheProvider }));
+
+const createFetchMock = (response: any) =>
+  vi.fn().mockResolvedValue({
+    ok: response.ok !== false,
+    status: response.status ?? 200,
+    json: async () => response.body,
+  });
+
+beforeEach(() => {
+  cacheMap.clear();
+  getMock.mockClear();
+  setMock.mockClear();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("planfixRequest", () => {
+  it("sends GET request with query params", async () => {
+    process.env.PLANFIX_ACCOUNT = "acc";
+    process.env.PLANFIX_TOKEN = "tok";
+    const fetchMock = createFetchMock({ body: { ok: true } });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { planfixRequest } = await import("./helpers.js");
+    const { PLANFIX_BASE_URL, PLANFIX_HEADERS } = await import("./config.js");
+
+    const result = await planfixRequest({
+      path: "task/list",
+      method: "GET",
+      body: { a: 1 },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(`${PLANFIX_BASE_URL}task/list?a=1`, {
+      method: "GET",
+      headers: PLANFIX_HEADERS,
+      body: undefined,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("throws error for non-ok response", async () => {
+    process.env.PLANFIX_ACCOUNT = "acc";
+    process.env.PLANFIX_TOKEN = "tok";
+    const fetchMock = createFetchMock({
+      ok: false,
+      status: 400,
+      body: { error: "bad" },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { planfixRequest } = await import("./helpers.js");
+
+    await expect(planfixRequest({ path: "x" })).rejects.toThrow("bad");
+  });
+
+  it("uses cache when cacheTime is set", async () => {
+    process.env.PLANFIX_ACCOUNT = "acc";
+    process.env.PLANFIX_TOKEN = "tok";
+    const fetchMock = createFetchMock({ body: { ok: true } });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { planfixRequest } = await import("./helpers.js");
+
+    const first = await planfixRequest({ path: "cached", cacheTime: 60 });
+    const second = await planfixRequest({ path: "cached", cacheTime: 60 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ ok: true });
+    expect(second).toEqual({ ok: true });
+    expect(getMock).toHaveBeenCalled();
+    expect(setMock).toHaveBeenCalled();
+  });
+});

--- a/src/tools/planfix_create_contact.test.ts
+++ b/src/tools/planfix_create_contact.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("../config.js", () => ({
+  PLANFIX_DRY_RUN: false,
+  PLANFIX_FIELD_IDS: {
+    telegram: 100,
+    telegramCustom: 1001,
+  },
+}));
+
+vi.mock("../customFieldsConfig.js", () => ({
+  customFieldsConfig: { contactFields: [] },
+}));
+
+vi.mock("../lib/extendPostBodyWithCustomFields.js", () => ({
+  extendPostBodyWithCustomFields: vi.fn(),
+}));
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return {
+    ...actual,
+    planfixRequest: vi.fn().mockResolvedValue({ id: 123 }),
+    getContactUrl: (id: number) => `https://example.com/contact/${id}`,
+    log: vi.fn(),
+  };
+});
+
+import { planfixRequest } from "../helpers.js";
+import { createPlanfixContact, handler } from "./planfix_create_contact.js";
+
+const mockRequest = vi.mocked(planfixRequest);
+
+describe("createPlanfixContact", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("handles dry run", async () => {
+    const original = await import("../config.js");
+    vi.resetModules();
+    vi.doMock("../config.js", () => ({ ...original, PLANFIX_DRY_RUN: true }));
+    const { createPlanfixContact: createDry } = await import(
+      "./planfix_create_contact.js"
+    );
+    const result = await createDry({ name: "John" });
+    expect(result.contactId).toBeGreaterThan(0);
+    expect(result.url).toContain("https://example.com/contact/");
+    expect(mockRequest).not.toHaveBeenCalled();
+    vi.resetModules();
+  });
+
+  it("sends telegram as custom field", async () => {
+    await createPlanfixContact({ name: "J", telegram: "@john" });
+    const call = mockRequest.mock.calls[0][0];
+    const body = call.body as any;
+    expect(body.customFieldData).toEqual(
+      expect.arrayContaining([{ field: { id: 1001 }, value: "@john" }])
+    );
+  });
+
+  it("returns zero on request error", async () => {
+    mockRequest.mockRejectedValueOnce(new Error("oops"));
+    const result = await createPlanfixContact({ name: "J" });
+    expect(result.contactId).toBe(0);
+    expect(result.url).toBeUndefined();
+  });
+});
+
+describe("handler", () => {
+  it("parses args and calls createPlanfixContact", async () => {
+    const res = await handler({ name: "Ann" });
+    expect(res.contactId).toBe(123);
+    expect(mockRequest).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- cover `planfixRequest` with unit tests

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_685ec395912c832c91b1767625c6fd41