### PR TITLE
Add tests for Planfix search tools

### DIFF
--- a/src/tools/planfix_create_comment.test.ts
+++ b/src/tools/planfix_create_comment.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return {
+    ...actual,
+    planfixRequest: vi.fn().mockResolvedValue({ id: 123 }),
+    log: vi.fn(),
+  };
+});
+
+vi.mock("../config.js", () => ({ PLANFIX_DRY_RUN: false }));
+
+import { planfixRequest } from "../helpers.js";
+import { createComment, handler } from "./planfix_create_comment.js";
+
+const mockRequest = vi.mocked(planfixRequest);
+
+describe("createComment", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("handles dry run", async () => {
+    const original = await import("../config.js");
+    vi.resetModules();
+    vi.doMock("../config.js", () => ({ ...original, PLANFIX_DRY_RUN: true }));
+    const { createComment: createDry } = await import(
+      "./planfix_create_comment.js"
+    );
+    const result = await createDry({ taskId: 1, description: "hi" });
+    expect(result.commentId).toBeGreaterThan(0);
+    expect(mockRequest).not.toHaveBeenCalled();
+    vi.resetModules();
+  });
+
+  it("sends request with default recipients", async () => {
+    const result = await createComment({
+      taskId: 1,
+      description: "Hello\nworld",
+    });
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.path).toBe("task/1/comments/");
+    expect((call.body as any).description).toBe("Hello<br>world");
+    expect((call.body as any).recipients).toEqual({ roles: ["assignee"] });
+    expect(result.commentId).toBe(123);
+  });
+
+  it("omits recipients when silent", async () => {
+    await createComment({ taskId: 2, description: "ok", silent: true });
+    const body = mockRequest.mock.calls[0][0].body as any;
+    expect(body.recipients).toBeUndefined();
+  });
+
+  it("returns error on request failure", async () => {
+    mockRequest.mockRejectedValueOnce(new Error("fail"));
+    const result = await createComment({ taskId: 3, description: "no" });
+    expect(result.commentId).toBe(0);
+    expect(result.error).toContain("fail");
+  });
+});
+
+describe("handler", () => {
+  it("parses args", async () => {
+    const res = await handler({ taskId: 4, description: "h" });
+    expect(res.commentId).toBe(123);
+    expect(mockRequest).toHaveBeenCalled();
+  });
+});

--- a/src/tools/planfix_get_report_fields.test.ts
+++ b/src/tools/planfix_get_report_fields.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return { ...actual, planfixRequest: vi.fn(), log: vi.fn() };
+});
+
+import { planfixRequest } from "../helpers.js";
+import {
+  getReportFields,
+  planfixGetReportFieldsTool,
+} from "./planfix_get_report_fields.js";
+
+const mockRequest = vi.mocked(planfixRequest);
+
+describe("getReportFields", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns fields when success", async () => {
+    mockRequest.mockResolvedValueOnce({
+      result: "success",
+      repost: {
+        id: 1,
+        name: "Rep",
+        fields: [{ id: 2, num: 1, name: "f", formula: "", hidden: false }],
+      },
+    });
+
+    const res = await getReportFields({ reportId: 1 });
+
+    expect(mockRequest).toHaveBeenCalledWith({
+      path: "report/1",
+      body: { fields: "id,name,fields" },
+      method: "GET",
+    });
+    expect(res.name).toBe("Rep");
+    expect(res.fields.length).toBe(1);
+  });
+
+  it("handles failed result", async () => {
+    mockRequest.mockResolvedValueOnce({ result: "fail", message: "oops" });
+    const res = await getReportFields({ reportId: 2 });
+    expect(res.error).toContain("oops");
+    expect(res.fields).toEqual([]);
+    expect(res.id).toBe(2);
+  });
+
+  it("handles request error", async () => {
+    mockRequest.mockRejectedValueOnce(new Error("err"));
+    const res = await getReportFields({ reportId: 3 });
+    expect(res.error).toContain("err");
+    expect(res.fields).toEqual([]);
+  });
+});
+
+describe("handler", () => {
+  it("parses args", async () => {
+    mockRequest.mockResolvedValueOnce({
+      result: "success",
+      repost: { id: 5, name: "N", fields: [] },
+    });
+    const res = (await planfixGetReportFieldsTool.handler({
+      reportId: 5,
+    })) as any;
+    expect(res.id).toBe(5);
+    expect(mockRequest).toHaveBeenCalled();
+  });
+});

--- a/src/tools/planfix_search_directory.test.ts
+++ b/src/tools/planfix_search_directory.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/planfixDirectory.js", () => ({
+  searchDirectory: vi.fn(),
+}));
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return { ...actual, log: vi.fn() };
+});
+
+import { searchDirectory } from "../lib/planfixDirectory.js";
+import planfixSearchDirectoryTool, {
+  planfixSearchDirectory,
+} from "./planfix_search_directory.js";
+
+const mockSearch = vi.mocked(searchDirectory);
+
+describe("planfixSearchDirectory", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns directory when found", async () => {
+    mockSearch.mockResolvedValueOnce({ id: 1, name: "Dir" });
+    const res = await planfixSearchDirectory({ name: "Dir" });
+    expect(res).toEqual({ directoryId: 1, name: "Dir", found: true });
+  });
+
+  it("returns not found", async () => {
+    mockSearch.mockResolvedValueOnce(undefined);
+    const res = await planfixSearchDirectory({ name: "None" });
+    expect(res.directoryId).toBe(0);
+    expect(res.found).toBe(false);
+  });
+
+  it("handles errors", async () => {
+    mockSearch.mockRejectedValueOnce(new Error("fail"));
+    const res = await planfixSearchDirectory({ name: "Err" });
+    expect(res.error).toBe("fail");
+    expect(res.found).toBe(false);
+  });
+});
+
+describe("handler", () => {
+  it("parses args", async () => {
+    mockSearch.mockResolvedValueOnce({ id: 2, name: "Dir" });
+    const result = (await planfixSearchDirectoryTool.handler({
+      name: "Dir",
+    })) as any;
+    expect(result.directoryId).toBe(2);
+    expect(mockSearch).toHaveBeenCalled();
+  });
+});

--- a/src/tools/planfix_search_directory_entry.test.ts
+++ b/src/tools/planfix_search_directory_entry.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/planfixDirectory.js", () => ({
+  searchDirectory: vi.fn(),
+  searchDirectoryEntryById: vi.fn(),
+  searchAllDirectoryEntries: vi.fn(),
+  getDirectoryFields: vi.fn(),
+}));
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return { ...actual, log: vi.fn() };
+});
+
+import {
+  searchDirectory,
+  searchDirectoryEntryById,
+  searchAllDirectoryEntries,
+  getDirectoryFields,
+} from "../lib/planfixDirectory.js";
+import planfixSearchDirectoryEntryTool, {
+  planfixSearchDirectoryEntry,
+} from "./planfix_search_directory_entry.js";
+
+const mDir = vi.mocked(searchDirectory);
+const mEntryById = vi.mocked(searchDirectoryEntryById);
+const mAll = vi.mocked(searchAllDirectoryEntries);
+const mFields = vi.mocked(getDirectoryFields);
+
+describe("planfixSearchDirectoryEntry", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns entry id from exact search", async () => {
+    mDir.mockResolvedValueOnce({ id: 1, name: "Dir" });
+    mFields.mockResolvedValueOnce([{ id: 11, name: "", type: 0 }]);
+    mEntryById.mockResolvedValueOnce(5);
+    const res = await planfixSearchDirectoryEntry({
+      directory: "Dir",
+      entry: "E",
+    });
+    expect(res).toEqual({ entryId: 5, found: true });
+    expect(mEntryById).toHaveBeenCalledWith(1, 11, "E");
+  });
+
+  it("falls back to search all entries", async () => {
+    mDir.mockResolvedValueOnce({ id: 1, name: "Dir" });
+    mFields.mockResolvedValueOnce([{ id: 11, name: "", type: 0 }]);
+    mEntryById.mockResolvedValueOnce(undefined);
+    mAll.mockResolvedValueOnce([
+      { key: 9, name: "One" },
+      { key: 10, name: "Entry" },
+    ]);
+    const res = await planfixSearchDirectoryEntry({
+      directory: "Dir",
+      entry: "entry",
+    });
+    expect(res).toEqual({ entryId: 10, found: true });
+  });
+
+  it("returns not found", async () => {
+    mDir.mockResolvedValueOnce({ id: 1, name: "Dir" });
+    mFields.mockResolvedValueOnce([{ id: 11, name: "", type: 0 }]);
+    mEntryById.mockResolvedValueOnce(undefined);
+    mAll.mockResolvedValueOnce([]);
+    const res = await planfixSearchDirectoryEntry({
+      directory: "Dir",
+      entry: "none",
+    });
+    expect(res).toEqual({ entryId: 0, found: false });
+  });
+
+  it("handles directory not found", async () => {
+    mDir.mockResolvedValueOnce(undefined);
+    const res = await planfixSearchDirectoryEntry({
+      directory: "Missing",
+      entry: "E",
+    });
+    expect(res.error).toBe("Directory not found");
+    expect(res.found).toBe(false);
+  });
+
+  it("handles fields missing", async () => {
+    mDir.mockResolvedValueOnce({ id: 1, name: "Dir" });
+    mFields.mockResolvedValueOnce(undefined as any);
+    const res = await planfixSearchDirectoryEntry({
+      directory: "Dir",
+      entry: "E",
+    });
+    expect(res.error).toBe("Directory fields not found");
+  });
+
+  it("handles errors", async () => {
+    mDir.mockRejectedValueOnce(new Error("boom"));
+    const res = await planfixSearchDirectoryEntry({
+      directory: "Dir",
+      entry: "E",
+    });
+    expect(res.error).toBe("boom");
+  });
+});
+
+describe("handler", () => {
+  it("parses args", async () => {
+    mDir.mockResolvedValueOnce({ id: 1, name: "Dir" });
+    mFields.mockResolvedValueOnce([{ id: 2, name: "", type: 0 }]);
+    mEntryById.mockResolvedValueOnce(7);
+    const result = (await planfixSearchDirectoryEntryTool.handler({
+      directory: "Dir",
+      entry: "En",
+    })) as any;
+    expect(result.entryId).toBe(7);
+    expect(result.found).toBe(true);
+  });
+});

--- a/src/tools/planfix_search_lead_task.test.ts
+++ b/src/tools/planfix_search_lead_task.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./planfix_search_contact.js", () => ({
+  planfixSearchContact: vi.fn(),
+}));
+vi.mock("./planfix_search_task.js", () => ({
+  searchPlanfixTask: vi.fn(),
+}));
+vi.mock("./planfix_search_company.js", () => ({
+  planfixSearchCompany: vi.fn(),
+}));
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return {
+    ...actual,
+    getTaskUrl: (id?: number) => (id ? `https://example.com/task/${id}` : ""),
+    getContactUrl: (id?: number) =>
+      id ? `https://example.com/contact/${id}` : "",
+    log: vi.fn(),
+  };
+});
+
+import { planfixSearchContact } from "./planfix_search_contact.js";
+import { searchPlanfixTask } from "./planfix_search_task.js";
+import { planfixSearchCompany } from "./planfix_search_company.js";
+import {
+  searchLeadTask,
+  planfixSearchLeadTaskTool,
+} from "./planfix_search_lead_task.js";
+
+const mContact = vi.mocked(planfixSearchContact);
+const mTask = vi.mocked(searchPlanfixTask);
+const mCompany = vi.mocked(planfixSearchCompany);
+
+describe("searchLeadTask", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns task and company", async () => {
+    mContact.mockResolvedValueOnce({
+      contactId: 1,
+      firstName: "A",
+      lastName: "B",
+      found: true,
+    } as any);
+    mTask.mockResolvedValueOnce({
+      taskId: 2,
+      assignees: { users: [] },
+      found: true,
+    } as any);
+    mCompany.mockResolvedValueOnce({ contactId: 3, found: true } as any);
+
+    const res = await searchLeadTask({ email: "a@b", company: "C" } as any);
+
+    expect(res).toEqual({
+      taskId: 2,
+      clientId: 1,
+      url: "https://example.com/task/2",
+      clientUrl: "https://example.com/contact/1",
+      assignees: { users: [] },
+      firstName: "A",
+      lastName: "B",
+      agencyId: 3,
+      found: true,
+    });
+    expect(mTask).toHaveBeenCalledWith({ clientId: 1 });
+  });
+
+  it("returns not found when contact missing", async () => {
+    mContact.mockResolvedValueOnce({ contactId: 0, found: false } as any);
+    const res = await searchLeadTask({ email: "x" } as any);
+    expect(res.found).toBe(false);
+    expect(mTask).not.toHaveBeenCalled();
+  });
+
+  it("handles errors", async () => {
+    mContact.mockRejectedValueOnce(new Error("fail"));
+    const res = await searchLeadTask({ email: "x" } as any);
+    expect(res.found).toBe(false);
+    expect(res.taskId).toBe(0);
+  });
+});
+
+describe("handler", () => {
+  it("parses args", async () => {
+    mContact.mockResolvedValueOnce({ contactId: 1, found: true } as any);
+    mTask.mockResolvedValueOnce({
+      taskId: 2,
+      assignees: { users: [] },
+      found: true,
+    } as any);
+    const res = (await planfixSearchLeadTaskTool.handler({
+      email: "x",
+    })) as any;
+    expect(res.taskId).toBe(2);
+  });
+});

--- a/src/tools/planfix_search_project.test.ts
+++ b/src/tools/planfix_search_project.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../helpers.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../helpers.js")>();
+  return { ...actual, planfixRequest: vi.fn(), log: vi.fn() };
+});
+
+import { planfixRequest } from "../helpers.js";
+import {
+  searchProject,
+  planfixSearchProjectTool,
+} from "./planfix_search_project.js";
+
+const mockRequest = vi.mocked(planfixRequest);
+
+describe("searchProject", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns project when found", async () => {
+    mockRequest.mockResolvedValueOnce({ projects: [{ id: 5, name: "Proj" }] });
+    const res = await searchProject({ name: "Proj" });
+    expect(mockRequest).toHaveBeenCalled();
+    expect(res).toEqual({ projectId: 5, name: "Proj", found: true });
+  });
+
+  it("returns not found", async () => {
+    mockRequest.mockResolvedValueOnce({ projects: [] });
+    const res = await searchProject({ name: "None" });
+    expect(res.projectId).toBe(0);
+    expect(res.found).toBe(false);
+  });
+
+  it("handles errors", async () => {
+    mockRequest.mockRejectedValueOnce(new Error("fail"));
+    const res = await searchProject({ name: "Err" });
+    expect(res.error).toBe("fail");
+    expect(res.found).toBe(false);
+  });
+});
+
+describe("handler", () => {
+  it("parses args", async () => {
+    mockRequest.mockResolvedValueOnce({ projects: [{ id: 6, name: "P" }] });
+    const res = (await planfixSearchProjectTool.handler({ name: "P" })) as any;
+    expect(res.projectId).toBe(6);
+    expect(mockRequest).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Planfix tools: create_comment, get_report_fields, search_directory, search_directory_entry, search_lead_task, search_project
- improve coverage of these modules to 100%

## Testing
- `npm test`
- `npm run coverage-info`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_685ec98b5280832c959b9f07cf81f4fd