### PR TITLE
Improve test coverage for entry files

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const connectMock = vi.fn().mockResolvedValue(undefined);
+const closeMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("./server.js", () => ({
+  createPlanfixServer: vi.fn(() => ({
+    connect: connectMock,
+    close: closeMock,
+  })),
+}));
+
+const StdioTransportMock = vi.fn();
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: StdioTransportMock,
+}));
+
+vi.mock("./helpers.js", () => ({ log: vi.fn() }));
+
+let exitSpy: any;
+let onSpy: any;
+
+beforeEach(() => {
+  vi.resetModules();
+  connectMock.mockClear();
+  closeMock.mockClear();
+  StdioTransportMock.mockClear();
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("exit");
+  });
+  onSpy = vi.spyOn(process, "on");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("index entry", () => {
+  it("starts server and handles SIGINT", async () => {
+    try {
+      await import("./index.js");
+    } catch (e) {
+      if ((e as Error).message !== "exit") throw e;
+    }
+
+    expect(StdioTransportMock).toHaveBeenCalled();
+    expect(connectMock).toHaveBeenCalled();
+    const sigHandler = onSpy.mock.calls.find(
+      (c: any) => c[0] === "SIGINT",
+    )?.[1];
+    expect(sigHandler).toBeTypeOf("function");
+    await expect(sigHandler()).rejects.toThrow("exit");
+    expect(closeMock).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/scripts/coverage-info.test.ts
+++ b/src/scripts/coverage-info.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+import { parseCoverage, coverageInfo } from "./coverage-info.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseCoverage", () => {
+  it("parses and sorts coverage data", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cov-"));
+    const file = path.join(tmpDir, "summary.json");
+    const data = {
+      total: {
+        lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
+        statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
+        functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
+        branches: { total: 0, covered: 0, skipped: 0, pct: 0 },
+      },
+    } as any;
+    const fileA = path.join(process.cwd(), "src", "a.ts");
+    const fileB = path.join(process.cwd(), "src", "b.ts");
+    data[fileA] = {
+      lines: { total: 10, covered: 5, skipped: 0, pct: 50 },
+      statements: { total: 10, covered: 5, skipped: 0, pct: 50 },
+      functions: { total: 2, covered: 1, skipped: 0, pct: 50 },
+      branches: { total: 0, covered: 0, skipped: 0, pct: 100 },
+    };
+    data[fileB] = {
+      lines: { total: 8, covered: 8, skipped: 0, pct: 100 },
+      statements: { total: 8, covered: 8, skipped: 0, pct: 100 },
+      functions: { total: 1, covered: 1, skipped: 0, pct: 100 },
+      branches: { total: 0, covered: 0, skipped: 0, pct: 100 },
+    };
+    fs.writeFileSync(file, JSON.stringify(data));
+
+    const result = parseCoverage(file);
+    expect(result.length).toBe(2);
+    expect(result[0].path).toContain("a.ts");
+    expect(result[0].lines_uncovered).toBe(5);
+    expect(result[1].path).toContain("b.ts");
+  });
+});
+
+describe("coverageInfo", () => {
+  it("prints parsed coverage", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cov-"));
+    const file = path.join(tmpDir, "summary.json");
+    const data = {
+      total: {
+        lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
+        statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
+        functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
+        branches: { total: 0, covered: 0, skipped: 0, pct: 0 },
+      },
+    } as any;
+    const fileA = path.join(process.cwd(), "src", "c.ts");
+    data[fileA] = {
+      lines: { total: 4, covered: 2, skipped: 0, pct: 50 },
+      statements: { total: 4, covered: 2, skipped: 0, pct: 50 },
+      functions: { total: 1, covered: 0, skipped: 0, pct: 0 },
+      branches: { total: 0, covered: 0, skipped: 0, pct: 100 },
+    };
+    fs.writeFileSync(file, JSON.stringify(data));
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    coverageInfo(file);
+
+    const expected = JSON.stringify(parseCoverage(file), null, 2);
+    expect(logSpy).toHaveBeenCalledWith(expected);
+  });
+});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./helpers.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./helpers.js")>("./helpers.js");
+  return {
+    ...actual,
+    log: vi.fn(),
+  };
+});
+
+const setRequestHandler = vi.fn();
+const ServerMock = vi.fn().mockImplementation(() => ({
+  setRequestHandler,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/index.js", () => ({
+  Server: ServerMock,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createPlanfixServer", () => {
+  it("registers request handlers", async () => {
+    const { createPlanfixServer, TOOLS } = await import("./server.js");
+    const server = createPlanfixServer();
+    expect(server).toBeDefined();
+    expect(ServerMock).toHaveBeenCalled();
+    expect(setRequestHandler).toHaveBeenCalledTimes(2);
+
+    const listHandler = setRequestHandler.mock.calls[0][1];
+    await expect(listHandler()).resolves.toEqual({ tools: TOOLS });
+
+    const callHandler = setRequestHandler.mock.calls[1][1];
+    const tool = { name: "t", handler: vi.fn(async () => "ok") };
+    (TOOLS as any).push(tool);
+    const result = await callHandler({ params: { name: "t", arguments: {} } });
+    expect(result.structuredContent).toBe("ok");
+  });
+});

--- a/src/sse-server.test.ts
+++ b/src/sse-server.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+
+const serverConnect = vi.fn();
+vi.mock("./server.js", () => ({
+  createPlanfixServer: () => ({ connect: serverConnect }),
+}));
+
+const transports: any[] = [];
+class SSEServerTransportMockClass {
+  sessionId: string;
+  handlePostMessage = vi.fn();
+  constructor(_endpoint: string, _res: any) {
+    void _endpoint;
+    void _res;
+    this.sessionId = `id${transports.length}`;
+    transports.push(this);
+  }
+}
+const SSEServerTransportMock = vi.fn(
+  (endpoint: string, res: any) =>
+    new SSEServerTransportMockClass(endpoint, res),
+);
+vi.mock("@modelcontextprotocol/sdk/server/sse.js", () => ({
+  SSEServerTransport: SSEServerTransportMock,
+}));
+
+let requestHandler: any;
+const listenMock = vi.fn();
+vi.mock("node:http", () => ({
+  default: {
+    createServer: vi.fn((handler: any) => {
+      requestHandler = handler;
+      return { listen: listenMock } as any;
+    }),
+  },
+}));
+
+vi.mock("./helpers.js", () => ({ log: vi.fn() }));
+
+beforeEach(() => {
+  vi.resetModules();
+  transports.length = 0;
+  listenMock.mockClear();
+  SSEServerTransportMock.mockClear();
+  serverConnect.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("sse server", () => {
+  it("handles connections and posts", async () => {
+    await import("./sse-server.js");
+    expect(listenMock).toHaveBeenCalled();
+
+    const res = new EventEmitter() as any;
+    res.on = EventEmitter.prototype.on;
+    res.end = vi.fn();
+    const req = { method: "GET", url: "/sse" } as any;
+    await requestHandler(req, res);
+    expect(SSEServerTransportMock).toHaveBeenCalledWith("/messages", res);
+    expect(serverConnect).toHaveBeenCalledWith(transports[0]);
+
+    const postRes = { end: vi.fn(), statusCode: 200 } as any;
+    const postReq = new EventEmitter() as any;
+    postReq.method = "POST";
+    postReq.url = `/messages?sessionId=${transports[0].sessionId}`;
+    await requestHandler(postReq, postRes);
+    expect(transports[0].handlePostMessage).toHaveBeenCalledWith(
+      postReq,
+      postRes,
+    );
+  });
+
+  it("returns 400 for unknown session", async () => {
+    await import("./sse-server.js");
+    const res = { end: vi.fn(), statusCode: undefined } as any;
+    const req = { method: "POST", url: "/messages?sessionId=unknown" } as any;
+    await requestHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.end).toHaveBeenCalledWith("No transport found for sessionId");
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for entrypoints and coverage info script
- mock SDK pieces to verify server integration
- ensure SSE server handles connections and missing session cases

## Testing
- `npm run test-full`
- `npm run coverage-info`

------
https://chatgpt.com/codex/tasks/task_e_685ef5347a0c832cbe4895e6ab8d1a3c