### PR TITLE
Improve coverage

### DIFF
--- a/src/tools/planfix_run_report.test.ts
+++ b/src/tools/planfix_run_report.test.ts
@@ -171,3 +171,29 @@ describe("processRows grouping and sorting", () => {
     expect(res.map((r) => r.value)).toEqual(["a", "c", "b"]);
   });
 });
+
+describe("runReport additional cases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns error when generateReport fails", async () => {
+    mockWithCache.mockResolvedValueOnce({ error: "boom" });
+    const { runReport } = await import("./planfix_run_report.js");
+    const res = await runReport({ reportId: 2 });
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("boom");
+  });
+
+  it("parses rows from report data", async () => {
+    const data = [
+      { type: "Header", items: [{ text: "A" }, { text: "B" }] },
+      { type: "Normal", items: [{ text: "1" }, { text: "2" }] },
+    ];
+    mockWithCache.mockResolvedValueOnce(data);
+    const { runReport } = await import("./planfix_run_report.js");
+    const res = await runReport({ reportId: 3 });
+    expect(res.success).toBe(true);
+    expect(res.rows).toEqual([{ A: "1", B: "2" }]);
+  });
+});

--- a/src/tools/planfix_update_lead_task.test.ts
+++ b/src/tools/planfix_update_lead_task.test.ts
@@ -72,7 +72,7 @@ describe("planfix_update_lead_task", () => {
     expect(updateCall.path).toBe("task/1");
     expect(updateCall.body).toMatchObject({
       template: { id: expect.any(Number) },
-      customFieldData: expect.any(Array)
+      customFieldData: expect.any(Array),
     });
     expect(result.taskId).toBe(1);
     expect(result.url).toBe("https://example.com/task/1");
@@ -88,11 +88,11 @@ describe("planfix_update_lead_task", () => {
         customFieldData: [],
       },
     });
-    
+
     // Second call - update task
     mockPlanfixRequest.mockResolvedValueOnce({
       id: 1,
-      status: { id: 3 }
+      status: { id: 3 },
     });
 
     const { updateLeadTask } = await import("./planfix_update_lead_task.js");
@@ -105,7 +105,7 @@ describe("planfix_update_lead_task", () => {
 
     // Verify the update call was made with the correct status
     expect(mockPlanfixRequest).toHaveBeenCalledTimes(2);
-    
+
     const updateCall = mockPlanfixRequest.mock.calls[1][0];
     expect(updateCall.body).toMatchObject({
       status: { id: 3 },
@@ -126,7 +126,7 @@ describe("planfix_update_lead_task", () => {
       ],
       status: { id: 1 },
     };
-    
+
     // Mock the get task call
     mockPlanfixRequest.mockResolvedValueOnce({
       task: mockTask,
@@ -151,7 +151,7 @@ describe("planfix_update_lead_task", () => {
 
     // Should be one call: just get task (no update since no changes)
     expect(mockPlanfixRequest).toHaveBeenCalledTimes(1);
-    
+
     // No update call should be made since no fields were actually changed
     // and forceUpdate is false
   });
@@ -174,5 +174,18 @@ describe("planfix_update_lead_task", () => {
     expect(res.taskId).toBe(2);
     expect(mockPlanfixRequest).not.toHaveBeenCalled();
     vi.resetModules();
+  });
+
+  it("handler invokes updateLeadTask", async () => {
+    mockPlanfixRequest.mockResolvedValueOnce({
+      task: { id: 1, customFieldData: [] },
+    });
+    mockPlanfixRequest.mockResolvedValueOnce({});
+    const mod = await import("./planfix_update_lead_task.js");
+    const res = (await mod.planfixUpdateLeadTaskTool.handler({
+      taskId: 1,
+      forceUpdate: true,
+    })) as { taskId: number };
+    expect(res.taskId).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add more helper tests
- cover planfix_run_report tool more
- test planfix_update_lead_task handler

## Testing
- `npm run test-full`
- `npm run coverage-info`

------
https://chatgpt.com/codex/tasks/task_e_685efa950d54832c9283c60615179359