### PR TITLE
Implement templateId and totalTasks features

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ const objects = await planfixClient.post('object/list', {
 ### Lead Management
 
 - `leadToTask`: Convert a lead to a task by creating/updating contact and task
-- `searchLeadTask`: Search for lead tasks by contact information
+ - `searchLeadTask`: Search for lead tasks by contact information. Returns `totalTasks`
 
 ### Contact Management
 
@@ -216,7 +216,7 @@ const objects = await planfixClient.post('object/list', {
 
 ### Task Management
 
-- `searchPlanfixTask`: Search for tasks by title and client ID
+ - `searchPlanfixTask`: Search for tasks by title, client ID and optional `templateId`. Returns `totalTasks`
 - `createSellTask`: Create a new sell task with template
 - `createLeadTask`: Create a new lead task
 - `addToLeadTask`: Create or update a lead task and update contact details

--- a/src/tools/planfix_search_task.test.ts
+++ b/src/tools/planfix_search_task.test.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.resetModules();
 });
 
 describe("searchPlanfixTask", () => {
@@ -49,6 +50,7 @@ describe("searchPlanfixTask", () => {
       assignees: { users: [] },
       url: "https://example.com/task/5",
       found: true,
+      totalTasks: 1,
     });
   });
 
@@ -68,6 +70,7 @@ describe("searchPlanfixTask", () => {
     });
     expect(res.taskId).toBe(2);
     expect(res.found).toBe(true);
+    expect(res.totalTasks).toBe(1);
   });
 
   it("returns found false when no task is found", async () => {
@@ -80,6 +83,7 @@ describe("searchPlanfixTask", () => {
     expect(res.found).toBe(false);
     expect(res.taskId).toBe(0);
     expect(res.url).toBe("");
+    expect(res.totalTasks).toBe(0);
   });
 
   it("handles request errors", async () => {
@@ -91,6 +95,7 @@ describe("searchPlanfixTask", () => {
     expect(res.found).toBe(false);
     expect(res.taskId).toBe(0);
     expect(res.url).toBe("");
+    expect(res.totalTasks).toBe(0);
   });
 
   it("handler parses args", async () => {
@@ -103,5 +108,15 @@ describe("searchPlanfixTask", () => {
 
     expect(res.taskId).toBe(10);
     expect(mockPlanfixRequest).toHaveBeenCalled();
+  });
+
+  it("uses provided templateId", async () => {
+    mockPlanfixRequest.mockResolvedValueOnce({ tasks: [{ id: 7 }] });
+    const { searchPlanfixTask } = await import("./planfix_search_task.js");
+
+    await searchPlanfixTask({ leadId: 1, templateId: 99 });
+
+    const call = mockPlanfixRequest.mock.calls[0][0];
+    expect((call.body as any).filters[0]).toMatchObject({ value: 99 });
   });
 });


### PR DESCRIPTION
## Summary
- support optional `templateId` in `searchPlanfixTask`
- show `totalTasks` in outputs for `searchPlanfixTask` and `searchLeadTask`
- pass template ID from environment in `searchLeadTask`
- update tests with module reset
- document new behavior in README

## Testing
- `npm run format`
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_6862792697e0832c8bd0e8e0a038e35a