### PR TITLE
Implement directory cache clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ npx @modelcontextprotocol/inspector node d:/projects/expertizeme/planfix-mcp-ser
 
 Set `LOG_LEVEL=debug` to enable detailed cache logs. Logs are written to `data/mcp.log`.
 
+### Clearing Cache
+
+Run `npm run cache-clear` to remove all cached Planfix API responses stored in `data/planfix-cache.sqlite3` and delete the objects cache file `data/planfix-cache.yml`.
+
 ## Example MCP Config (NPX)
 
 ```json

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:integration": "cross-env CI=1 npx vitest integration",
     "test-full": "npm run typecheck && npm run test && npm run lint src",
     "coverage-info": "tsx src/scripts/coverage-info.ts",
+    "cache-clear": "tsx src/scripts/cache-clear.ts",
     "prepare-build": "npm run build && npm run test-full",
     "prepublishOnly": "npm run prepare-build",
     "mcp-cli": "mcp-inspector --cli npm run dev",

--- a/src/lib/planfixDirectory.test.ts
+++ b/src/lib/planfixDirectory.test.ts
@@ -12,6 +12,10 @@ vi.mock("../helpers.js", () => ({
   log: vi.fn(),
   planfixRequest: vi.fn(),
 }));
+const deletePrefixMock = vi.fn();
+vi.mock("./cache.js", () => ({
+  getCacheProvider: () => ({ deletePrefix: deletePrefixMock }),
+}));
 
 const mockedLog = vi.mocked(log);
 const mockedPlanfixRequest = vi.mocked(planfixRequest);
@@ -160,16 +164,19 @@ describe("createDirectoryEntry", () => {
     const result = await createDirectoryEntry(dirId, fieldId, name);
     expect(mockedPlanfixRequest).toHaveBeenCalled();
     expect(result).toBe(12);
+    expect(deletePrefixMock).toHaveBeenCalledWith(`directory/${dirId}`);
   });
   it("handles entry object response", async () => {
     mockedPlanfixRequest.mockResolvedValueOnce({ entry: { key: 13 } });
     const result = await createDirectoryEntry(dirId, fieldId, name);
     expect(result).toBe(13);
+    expect(deletePrefixMock).toHaveBeenCalledWith(`directory/${dirId}`);
   });
   it("returns undefined on error", async () => {
     mockedPlanfixRequest.mockRejectedValueOnce(new Error("err"));
     const result = await createDirectoryEntry(dirId, fieldId, name);
     expect(result).toBeUndefined();
     expect(mockedLog).toHaveBeenCalled();
+    expect(deletePrefixMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/planfixDirectory.ts
+++ b/src/lib/planfixDirectory.ts
@@ -1,4 +1,5 @@
 import { log, planfixRequest } from "../helpers.js";
+import { getCacheProvider } from "./cache.js";
 import type { CustomFieldDataType } from "../types.js";
 
 export interface DirectoryInfo {
@@ -150,8 +151,11 @@ export async function createDirectoryEntry(
         ],
       },
     });
-    const key = (result as { key?: number; entry?: { key: number } }).key ??
+    const key =
+      (result as { key?: number; entry?: { key: number } }).key ??
       (result as { key?: number; entry?: { key: number } }).entry?.key;
+    const cache = getCacheProvider();
+    await cache.deletePrefix?.(`directory/${directoryId}`);
     return typeof key === "number" ? key : undefined;
   } catch (error) {
     log(`[createDirectoryEntry] ${(error as Error).message}`);

--- a/src/lib/planfixObjects.test.ts
+++ b/src/lib/planfixObjects.test.ts
@@ -7,6 +7,7 @@ import {
   getObjects,
   getObjectsNames,
   getFieldDirectoryId,
+  clearObjectsCache,
 } from "./planfixObjects.js";
 
 function tmpCache(data: any): string {
@@ -67,5 +68,11 @@ describe("planfixObjects", () => {
       cachePath: cache,
     });
     expect(id).toBe(333);
+  });
+
+  it("removes cache file", async () => {
+    const cache = tmpCache({});
+    await clearObjectsCache(cache);
+    expect(fs.existsSync(cache)).toBe(false);
   });
 });

--- a/src/lib/planfixObjects.ts
+++ b/src/lib/planfixObjects.ts
@@ -119,8 +119,8 @@ export async function getFieldDirectoryId({
   const objects = await ensureCache(cachePath);
   const obj = objectName
     ? objects[objectName]
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    : Object.entries(objects).find(([_, o]) => o.id === objectId)?.[1];
+    : // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      Object.entries(objects).find(([_, o]) => o.id === objectId)?.[1];
   if (!obj) return undefined;
   interface CustomField {
     field: { name: string; directoryId?: number; id?: number };
@@ -136,4 +136,20 @@ export async function getFieldDirectoryId({
     );
   }
   return field?.field.directoryId;
+}
+
+export function getObjectsCachePath(): string {
+  return getDefaultCachePath();
+}
+
+export async function clearObjectsCache(
+  cachePath: string = getDefaultCachePath(),
+): Promise<void> {
+  try {
+    await fsp.unlink(cachePath);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw e;
+    }
+  }
 }

--- a/src/scripts/cache-clear.test.ts
+++ b/src/scripts/cache-clear.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, vi, expect } from "vitest";
+let clearObjectsCacheMock: any;
+const clearMock = vi.fn();
+vi.mock("../lib/cache.js", () => ({
+  getCacheProvider: () => ({ clear: clearMock }),
+}));
+vi.mock("../lib/planfixObjects.js", () => {
+  clearObjectsCacheMock = vi.fn();
+  return { clearObjectsCache: clearObjectsCacheMock };
+});
+
+describe("cacheClear", () => {
+  it("clears cache and objects cache file", async () => {
+    const { cacheClear } = await import("./cache-clear.js");
+    await cacheClear();
+    expect(clearMock).toHaveBeenCalled();
+    expect(clearObjectsCacheMock).toHaveBeenCalled();
+  });
+});

--- a/src/scripts/cache-clear.ts
+++ b/src/scripts/cache-clear.ts
@@ -1,0 +1,16 @@
+import { getCacheProvider } from "../lib/cache.js";
+import { clearObjectsCache } from "../lib/planfixObjects.js";
+
+export async function cacheClear(): Promise<void> {
+  const cache = getCacheProvider();
+  await cache.clear?.();
+  await clearObjectsCache();
+}
+
+const currentFileUrl = new URL(import.meta.url);
+if (
+  process.argv[1] &&
+  new URL(`file://${process.argv[1]}`).href === currentFileUrl.href
+) {
+  cacheClear();
+}


### PR DESCRIPTION
## Summary
- clear directory cache entries after creating directory entry
- expose cache clearing helpers in cache provider
- add CLI script and npm command `cache-clear`
- document cache clearing command in README
- test new behavior
- remove cache file `planfix-cache.yml` via `cache-clear`

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_6862b2d8a0c0832c9444edd071b6eb90