### PR TITLE
Add customizable lead task title

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The server requires the following environment variables for Planfix API access:
   - Missing tag names will be added automatically to the directory
 - `PLANFIX_FIELD_ID_LEAD_ID` – Custom field ID for external lead ID
 - `PLANFIX_LEAD_TEMPLATE_ID` – ID of the lead task template
-- `PLANFIX_TASK_TITLE_TEMPLATE` – Template for the default lead task title (e.g., `{name} - работа с клиентом`)
+- `PLANFIX_TASK_TITLE_TEMPLATE` – Template for the default lead task title (e.g., `{name} - client's task`)
 
 ### config.yml
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The server requires the following environment variables for Planfix API access:
   - Missing tag names will be added automatically to the directory
 - `PLANFIX_FIELD_ID_LEAD_ID` – Custom field ID for external lead ID
 - `PLANFIX_LEAD_TEMPLATE_ID` – ID of the lead task template
+- `PLANFIX_TASK_TITLE_TEMPLATE` – Template for the default lead task title (e.g., `{name} - работа с клиентом`)
 
 ### config.yml
 
@@ -101,7 +102,8 @@ Run `npm run cache-clear` to remove all cached Planfix API responses stored in `
         "PLANFIX_FIELD_ID_AGENCY": "128",
         "PLANFIX_FIELD_ID_TAGS": "129",
         "PLANFIX_FIELD_ID_LEAD_ID": "130",
-        "PLANFIX_LEAD_TEMPLATE_ID": "42"
+        "PLANFIX_LEAD_TEMPLATE_ID": "42",
+        "PLANFIX_TASK_TITLE_TEMPLATE": "{name} - работа с клиентом"
       }
     }
   }
@@ -130,6 +132,7 @@ PLANFIX_FIELD_ID_PIPELINE=131 \
 PLANFIX_FIELD_ID_LEAD_ID=132 \
 PLANFIX_FIELD_ID_TAGS=133 \
 PLANFIX_LEAD_TEMPLATE_ID=42 \
+PLANFIX_TASK_TITLE_TEMPLATE="{name} - работа с клиентом" \
 npx @popstas/planfix-mcp-server
 ```
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,8 +20,7 @@ export const PLANFIX_HEADERS = {
 
 export const PLANFIX_DRY_RUN = Boolean(process.env.PLANFIX_DRY_RUN);
 
-export const PLANFIX_TASK_TITLE_TEMPLATE =
-  process.env.PLANFIX_TASK_TITLE_TEMPLATE || "{name} - работа с клиентом";
+export const PLANFIX_TASK_TITLE_TEMPLATE = process.env.PLANFIX_TASK_TITLE_TEMPLATE || "";
 
 export const PLANFIX_FIELD_IDS = {
   email: Number(process.env.PLANFIX_FIELD_ID_EMAIL || 108),

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,9 @@ export const PLANFIX_HEADERS = {
 
 export const PLANFIX_DRY_RUN = Boolean(process.env.PLANFIX_DRY_RUN);
 
+export const PLANFIX_TASK_TITLE_TEMPLATE =
+  process.env.PLANFIX_TASK_TITLE_TEMPLATE || "{name} - работа с клиентом";
+
 export const PLANFIX_FIELD_IDS = {
   email: Number(process.env.PLANFIX_FIELD_ID_EMAIL || 108),
   phone: Number(process.env.PLANFIX_FIELD_ID_PHONE || 105),

--- a/src/tools/planfix_add_to_lead_task.ts
+++ b/src/tools/planfix_add_to_lead_task.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { PLANFIX_DRY_RUN } from "../config.js";
+import { PLANFIX_DRY_RUN, PLANFIX_TASK_TITLE_TEMPLATE } from "../config.js";
 import {
   log,
   getToolWithHandler,
@@ -106,13 +106,12 @@ export async function addToLeadTask(
   // Helper: template string replacement
   function replaceTemplateVars(
     template: string,
-    vars: Record<string, string | undefined>,
+    vars: Record<string, unknown>,
   ): string {
-    let result = template;
-    for (const [key, value] of Object.entries(vars)) {
-      result = result.replace(new RegExp(`{${key}}`, "g"), value ?? "");
-    }
-    return result;
+    return template.replace(/\{([^}]+)\}/g, (_, key) => {
+      const value = vars[key];
+      return value !== undefined && value !== null ? String(value) : "";
+    });
   }
 
   // Main logic
@@ -139,12 +138,12 @@ export async function addToLeadTask(
     let { taskId, clientId, url, clientUrl, assignees } = searchResult;
     // Variables that won't be reassigned
     const { firstName, lastName, agencyId } = searchResult;
-    const taskTitleTemplate = "{clientName} - работа с клиентом";
     const finalTaskTitle = title
       ? title
-      : replaceTemplateVars(taskTitleTemplate, {
-          clientName: userData.name,
-        });
+      : replaceTemplateVars(
+          PLANFIX_TASK_TITLE_TEMPLATE,
+          args as Record<string, unknown>,
+        );
 
     const descriptionText = generateDescription(
       userData,
@@ -174,7 +173,7 @@ export async function addToLeadTask(
         errors.push(createResult.error);
       }
     } else if (clientId) {
-    // 3. Update contact with provided data
+      // 3. Update contact with provided data
       await updatePlanfixContact({
         contactId: clientId,
         name: userData.name,

--- a/src/tools/planfix_add_to_lead_task.ts
+++ b/src/tools/planfix_add_to_lead_task.ts
@@ -184,7 +184,7 @@ export async function addToLeadTask(
       });
     }
     // 4. If task not found and name has space, search by name
-    if (clientId && !taskId && userData.name && userData.name.includes(" ")) {
+    if (clientId && !taskId && userData.name && userData.name.includes(" ") && finalTaskTitle) {
       // console.log('[leadToTask] Searching for task by name...');
       const result = await searchPlanfixTask({
         taskTitle: finalTaskTitle,

--- a/src/tools/planfix_create_lead_task.ts
+++ b/src/tools/planfix_create_lead_task.ts
@@ -20,7 +20,7 @@ import { extendSchemaWithCustomFields } from "../lib/extendSchemaWithCustomField
 import { extendPostBodyWithCustomFields } from "../lib/extendPostBodyWithCustomFields.js";
 
 const CreateLeadTaskInputSchemaBase = z.object({
-  name: z.string(),
+  name: z.string().optional().describe("Name of the task"),
   description: z.string(),
   clientId: z.number(),
   managerId: z.number().optional(),


### PR DESCRIPTION
## Summary
- allow configuring lead task title via `PLANFIX_TASK_TITLE_TEMPLATE`
- update `addToLeadTask` to use the template and dynamic placeholders
- document the new environment variable
- test custom title template logic

## Testing
- `npm run test-full`

------
https://chatgpt.com/codex/tasks/task_e_6867e57c4b08832c885bdf1039ca3bbd