### PR TITLE
Add instagram field to contact handlers

### DIFF
--- a/src/tools/planfix_create_task.ts
+++ b/src/tools/planfix_create_task.ts
@@ -14,6 +14,7 @@ const PlanfixCreateTaskInputSchemaBase = z.object({
   name: z.string().optional().describe("Name of the client"),
   nameTranslated: z.string().optional().describe("Translated name of the client"),
   phone: z.string().optional().describe("Phone of the client"),
+  instagram: z.string().optional(),
   email: z.string().optional(),
   telegram: z.string().optional(),
   leadSource: z.string().optional(),

--- a/src/tools/planfix_update_contact.ts
+++ b/src/tools/planfix_update_contact.ts
@@ -24,6 +24,7 @@ const UpdatePlanfixContactInputSchemaBase = z.object({
   contactId: z.number(),
   name: z.string().optional(),
   telegram: z.string().optional(),
+  instagram: z.string().optional(),
   email: z.string().optional(),
   phone: z.string().optional(),
   forceUpdate: z.boolean().optional(),
@@ -43,14 +44,17 @@ export const UpdatePlanfixContactOutputSchema = z.object({
 export async function updatePlanfixContact(
   args: z.infer<typeof UpdatePlanfixContactInputSchema>,
 ): Promise<z.infer<typeof UpdatePlanfixContactOutputSchema>> {
-  const { contactId, name, telegram, email, phone, forceUpdate } = args;
+  const { contactId, name, telegram, instagram, email, phone, forceUpdate } =
+    args;
   try {
     if (PLANFIX_DRY_RUN) {
       log(`[DRY RUN] Would update contact ${contactId}`);
       return { contactId, url: getContactUrl(contactId) };
     }
 
-    const customContactFieldsIds = customFieldsConfig.contactFields.map((f) => f.id);
+    const customContactFieldsIds = customFieldsConfig.contactFields.map(
+      (f) => f.id,
+    );
     const fieldsBase = `id,name,lastname,email,phones,${customContactFieldsIds.join(",")}`;
     const fields = PLANFIX_FIELD_IDS.telegramCustom
       ? `${fieldsBase},${PLANFIX_FIELD_IDS.telegramCustom}`
@@ -114,6 +118,10 @@ export async function updatePlanfixContact(
           postBody.telegram = normalized;
         }
       }
+    }
+
+    if (instagram !== undefined) {
+      postBody.instagram = instagram.replace(/^@/, "");
     }
 
     const cleanPhone = (phone: string) => phone.replace(/[^0-9]/g, "");

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export const UserDataInputSchemaBase = z.object({
   phone: z.string().optional(),
   email: z.string().optional(),
   telegram: z.string().optional(),
+  instagram: z.string().optional(),
   company: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary
- extend `UserDataInputSchema` with optional `instagram`
- support instagram in `createPlanfixContact` and `updatePlanfixContact`

## Testing
- `npm test`
- `npm run coverage-info`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_686bd64fa094832cbf3726a01c6c014b