### PR TITLE
Fix typecheck and update contact tests

### DIFF
--- a/src/lib/extendFiltersWithCustomFields.ts
+++ b/src/lib/extendFiltersWithCustomFields.ts
@@ -29,7 +29,7 @@ export function extendFiltersWithCustomFields(
   target: "task" | "contact",
 ): void {
   for (const field of fields) {
-    const type = (typeCodeMap as any)[target][field.type as string];
+    const type = (typeCodeMap as Record<string, Record<string, number>>)[target][field.type as string];
     if (!type) {
       log(`[extendFiltersWithCustomFields] Unknown type: ${field.type}, field: ${field.id}`);
       continue;

--- a/src/lib/extendPostBodyWithCustomFields.test.ts
+++ b/src/lib/extendPostBodyWithCustomFields.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { extendPostBodyWithCustomFields } from "./extendPostBodyWithCustomFields.js";
+import type { HasCustomFieldData } from "./extendPostBodyWithCustomFields.js";
 import type { CustomField } from "./extendSchemaWithCustomFields.js";
 import type { TaskResponse, ContactResponse } from "../types.js";
 
@@ -12,37 +13,42 @@ describe("extendPostBodyWithCustomFields", () => {
     values: ["one", "two"],
   };
 
-  it("adds custom field data from args", () => {
-    const body: Record<string, any> = {};
-    extendPostBodyWithCustomFields(body, { name: "A" }, [stringField]);
+  it("adds custom field data from args", async () => {
+    const body: HasCustomFieldData = { template: { id: 1 } };
+    await extendPostBodyWithCustomFields(body, { name: "A" }, [stringField]);
     expect(body.customFieldData).toEqual([{ field: { id: 1 }, value: "A" }]);
   });
 
-  it("uses default when arg missing", () => {
-    const body: Record<string, any> = {};
-    extendPostBodyWithCustomFields(body, {}, [
+  it("uses default when arg missing", async () => {
+    const body: HasCustomFieldData = { template: { id: 1 } };
+    await extendPostBodyWithCustomFields(body, {}, [
       { ...stringField, default: "B" },
     ]);
     expect(body.customFieldData).toEqual([{ field: { id: 1 }, value: "B" }]);
   });
 
-  it("skips when enum value unchanged and forceUpdate is false", () => {
-    const body: Record<string, any> = {};
+  it("skips when enum value unchanged and forceUpdate is false", async () => {
+    const body: HasCustomFieldData = { template: { id: 1 } };
     const task: TaskResponse = {
       id: 1,
       customFieldData: [{ field: { id: 2 }, value: ["one"] }],
     } as TaskResponse;
-    extendPostBodyWithCustomFields(body, { status: "one" }, [enumField], task);
+    await extendPostBodyWithCustomFields(
+      body,
+      { status: "one" },
+      [enumField],
+      task,
+    );
     expect(body.customFieldData).toBeUndefined();
   });
 
-  it("updates when forceUpdate is true", () => {
-    const body: Record<string, any> = {};
+  it("updates when forceUpdate is true", async () => {
+    const body: HasCustomFieldData = { template: { id: 1 } };
     const contact: ContactResponse = {
       id: 1,
       customFieldData: [{ field: { id: 2 }, value: ["one"] }],
     } as ContactResponse;
-    extendPostBodyWithCustomFields(
+    await extendPostBodyWithCustomFields(
       body,
       { status: "one" },
       [enumField],

--- a/src/tools/planfix_update_contact.ts
+++ b/src/tools/planfix_update_contact.ts
@@ -145,7 +145,11 @@ export async function updatePlanfixContact(
       contact,
     );
 
-    if (Object.keys(postBody).length === 0) {
+    const hasUpdates =
+      Object.keys(postBody).some(
+        (k) => k !== "template" && k !== "customFieldData",
+      ) || postBody.customFieldData.length > 0;
+    if (!hasUpdates) {
       return { contactId, url: getContactUrl(contactId) };
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node", "vitest"]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## Summary
- include node and vitest types in tsconfig
- adjust extendPostBodyWithCustomFields tests to use new interface
- ensure updatePlanfixContact detects when no updates are needed

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_687fd1b45bd0832c8e2243a5206a00de