### PR TITLE
feat: add Chat API config loader

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,18 @@
+chatApi:
+  chatApiToken: "<token>"
+  providerId: "<id>"
+  useChatApi: true
+  baseUrl: "https://<account>.planfix.com/webchat/api"
+
+leadTaskFields:
+  - id: "456"
+    name: "id сделки"
+    argName: lead_id
+    type: number
+
+contactFields:
+  - id: "123"
+    name: "Резидентство"
+    argName: resident
+    type: enum
+    values: ["резидент", "нерезидент", "иное"]

--- a/src/customFieldsConfig.test.ts
+++ b/src/customFieldsConfig.test.ts
@@ -46,4 +46,30 @@ describe("customFieldsConfig", () => {
     const cfg = loadCustomFieldsConfig();
     expect(cfg.contactFields[0].values).toEqual(["one", "two"]);
   });
+
+  it("loads chatApi from yaml", () => {
+    const file = tmpFile(
+      "chatApi:\n  chatApiToken: t\n  providerId: p\n  useChatApi: true\n  baseUrl: https://a.planfix.com/webchat/api",
+    );
+    process.env.PLANFIX_CONFIG = file;
+    const cfg = loadCustomFieldsConfig();
+    expect(cfg.chatApi).toEqual({
+      chatApiToken: "t",
+      providerId: "p",
+      useChatApi: true,
+      baseUrl: "https://a.planfix.com/webchat/api",
+    });
+  });
+
+  it("chatApi defaults when missing", () => {
+    const file = tmpFile("leadTaskFields: []\ncontactFields: []");
+    process.env.PLANFIX_CONFIG = file;
+    const cfg = loadCustomFieldsConfig();
+    expect(cfg.chatApi).toEqual({
+      chatApiToken: "",
+      providerId: "",
+      useChatApi: false,
+      baseUrl: "",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- support Chat API configuration via YAML file and expose chatApiConfig
- test loader for Chat API YAML loading and defaults
- provide sample config.example.yml and stop tracking data/config.yml

## Testing
- `npm test`
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_68adcea937b0832cbaae50ed3f460388