### PR TITLE
feat: add chat API request helper

### DIFF
--- a/src/chatApi.test.ts
+++ b/src/chatApi.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+vi.mock("./customFieldsConfig.js", () => ({
+  chatApiConfig: {
+    chatApiToken: "tkn",
+    providerId: "pid",
+    useChatApi: true,
+    baseUrl: "",
+  },
+}));
+
+const createFetchMock = (body: any) =>
+  vi.fn().mockResolvedValue({ ok: true, json: async () => body });
+
+describe("chatApiRequest", () => {
+  beforeEach(() => {
+    process.env.PLANFIX_ACCOUNT = "acc";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("sends request with cmd and tokens", async () => {
+    const fetchMock = createFetchMock({ chatId: 1, contactId: 2 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { chatApiRequest } = await import("./chatApi.js");
+    const res = await chatApiRequest("init", { a: 1 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://acc.planfix.com/webchat/api?planfix_token=tkn&providerId=pid",
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ cmd: "init", params: { a: 1 } }),
+      },
+    );
+    expect(res).toEqual({ chatId: 1, contactId: 2 });
+  });
+});

--- a/src/chatApi.ts
+++ b/src/chatApi.ts
@@ -1,0 +1,52 @@
+import { PLANFIX_ACCOUNT } from "./config.js";
+import { chatApiConfig } from "./customFieldsConfig.js";
+
+export interface ChatApiRequestBody<TParams = Record<string, unknown>> {
+  cmd: string;
+  params?: TParams;
+}
+
+export interface ChatApiChatResponse {
+  chatId: number;
+  contactId: number;
+}
+
+export interface ChatApiNumberResponse {
+  data: { number: number };
+}
+
+export async function chatApiRequest<
+  TResponse = unknown,
+  TParams = Record<string, unknown>,
+>(cmd: string, params?: TParams): Promise<TResponse> {
+  if (!PLANFIX_ACCOUNT) {
+    throw new Error("PLANFIX_ACCOUNT is not defined");
+  }
+
+  const baseUrl =
+    chatApiConfig.baseUrl ||
+    `https://${PLANFIX_ACCOUNT}.planfix.com/webchat/api`;
+  const url = new URL(baseUrl);
+  url.searchParams.set("planfix_token", chatApiConfig.chatApiToken);
+  url.searchParams.set("providerId", chatApiConfig.providerId);
+
+  const body: ChatApiRequestBody<TParams> = { cmd };
+  if (params) {
+    body.params = params;
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Chat API request failed with status ${response.status}`);
+  }
+
+  return (await response.json()) as TResponse;
+}


### PR DESCRIPTION
## Summary
- add chatApiRequest helper for Planfix webchat API
- add TypeScript types and tests for chat API requests

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_68ade58d8094832cbd33aba21b59bbf7