### PR TITLE
feat: support chat API for lead task creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,11 @@ const objects = await planfixClient.post('object/list', {
 
 ### Task Management
 
- - `searchPlanfixTask`: Search for tasks by title, client ID and optional `templateId`
+- `searchPlanfixTask`: Search for tasks by title, client ID and optional `templateId`
 - `createSellTask`: Create a new sell task with template
-- `createLeadTask`: Create a new lead task
+- `createLeadTask`: Create a new lead task. Supports Chat API when
+  `chatApi.useChatApi` is enabled in config, accepting `message` and
+  `contactName` fields.
 - `addToLeadTask`: Create or update a lead task and update contact details
 - `createTask`: Create a task using text fields
 - `createComment`: Add a comment to a task


### PR DESCRIPTION
## Summary
- add chat API flow for lead task creation with contact updates
- extend lead task schema with chat fields like `message` and `contactName`
- document new chat API option in README and cover with tests

## Testing
- `npm test`
- `npm run coverage-info`
- `npm run lint src/tools/planfix_create_lead_task.ts src/tools/planfix_create_lead_task.test.ts`
- `npm run test-full`


------
https://chatgpt.com/codex/tasks/task_e_68adea6b3a64832cab5b8859fcb90d44