### PR TITLE
test: ensure chat API updates called once

### DIFF
--- a/src/tools/planfix_create_lead_task.test.ts
+++ b/src/tools/planfix_create_lead_task.test.ts
@@ -171,9 +171,11 @@ describe("planfix_create_lead_task", () => {
     expect(mockUpdateLeadTask).toHaveBeenCalledWith(
       expect.objectContaining({ taskId: 33 }),
     );
+    expect(mockUpdateLeadTask).toHaveBeenCalledTimes(1);
     expect(mockUpdatePlanfixContact).toHaveBeenCalledWith(
       expect.objectContaining({ contactId: 22, email: "a@b.c" }),
     );
+    expect(mockUpdatePlanfixContact).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ taskId: 33, url: "https://example.com/task/33" });
     expect(mockPlanfixRequest).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- assert chat API path updates lead task and contact exactly once

## Testing
- `npm run test-full`
- `npm run coverage-info`


------
https://chatgpt.com/codex/tasks/task_e_68adf2b843e0832c9025f67c4537eb30