### PR TITLE
Make leadTaskId optional in planfix_create_sell_task

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ PLANFIX_TOKEN=your-api-token
    npm run planfix post object/list --data '{"filters":[{"type":1,"operator":"equal","value":"Продажа"}]}'
    ```
 
+## Tool Reference
+
+### `planfix_create_sell_task`
+
+- Creates a sell task using the Planfix template defined by `PLANFIX_SELL_TEMPLATE_ID`.
+- `leadTaskId` is optional; when omitted, the sell task is created without a parent lead task.
+
 5. **Update an object (PUT request)**
    ```bash
    npm run planfix put task/123 --data '{"name":"Updated Task Name"}'

--- a/src/tools/planfix_create_sell_task.test.ts
+++ b/src/tools/planfix_create_sell_task.test.ts
@@ -88,6 +88,19 @@ describe("createSellTask", () => {
     expect(body.description).toContain("Проект: Missing");
   });
 
+  it("omits parent when leadTaskId is not provided", async () => {
+    process.env.PLANFIX_SELL_TEMPLATE_ID = "11";
+
+    await createSellTask({
+      clientId: 1,
+      name: "Name",
+      description: "Desc",
+    });
+
+    const body = mockRequest.mock.calls[0][0].body as any;
+    expect(body.parent).toBeUndefined();
+  });
+
   it("handles dry run", async () => {
     const original = await import("../config.js");
     vi.resetModules();
@@ -100,7 +113,6 @@ describe("createSellTask", () => {
     );
     const res = await createDry({
       clientId: 1,
-      leadTaskId: 2,
       name: "",
       description: "",
     });


### PR DESCRIPTION
## Summary
- allow the `planfix_create_sell_task` tool to accept an optional `leadTaskId` when creating a sell task
- skip sending the parent task when no lead task is provided and keep logging clear in dry-run mode
- document the tool behavior and cover the new case with unit tests

## Testing
- npm run format
- npm run test-full

------
https://chatgpt.com/codex/tasks/task_e_68da9aeca1f0832cb5e393962429c842