### PR TITLE
Allow sell task creation without resolved contact

### DIFF
--- a/src/tools/planfix_create_sell_task.test.ts
+++ b/src/tools/planfix_create_sell_task.test.ts
@@ -90,21 +90,27 @@ describe("createSellTask", () => {
     });
   });
 
-  it("throws when contact cannot be resolved", async () => {
+  it("continues when contact cannot be resolved", async () => {
     mockSearchLeadTask.mockResolvedValue({
       clientId: 0,
       taskId: 0,
     } as any);
 
-    await expect(
-      createSellTask({
-        name: "Продажа",
-        email: "missing@example.com",
-        description: "описание",
-      }),
-    ).rejects.toThrow(
-      "Unable to find a Planfix contact for the provided email/telegram",
-    );
-    expect(mockCreateSellTaskIds).not.toHaveBeenCalled();
+    const result = await createSellTask({
+      name: "Продажа",
+      email: "missing@example.com",
+      description: "описание",
+    });
+
+    expect(result).toEqual({ taskId: 321, url: "url" });
+    expect(mockCreateSellTaskIds).toHaveBeenCalledWith({
+      clientId: 0,
+      leadTaskId: undefined,
+      agencyId: undefined,
+      assignees: undefined,
+      name: "Продажа",
+      description: "описание",
+      project: undefined,
+    });
   });
 });

--- a/src/tools/planfix_create_sell_task.ts
+++ b/src/tools/planfix_create_sell_task.ts
@@ -68,10 +68,6 @@ export async function createSellTask(
   } = searchResult;
   let resolvedAgencyId = initialAgencyId;
 
-  if (!clientId) {
-    log("Unable to find a Planfix contact for the provided email/telegram");
-  }
-
   if (!resolvedAgencyId && agency) {
     try {
       const companyResult = await planfixSearchCompany({ name: agency });


### PR DESCRIPTION
## Summary
- restore `createSellTask` so it continues even when a client contact cannot be resolved
- update the sell task tool tests to expect task creation to proceed without a contact id

## Testing
- npm run test-full
- npm run test -- planfix_create_sell_task

------
https://chatgpt.com/codex/tasks/task_e_68e10fc7f46c832cbcabf631de8dd3e3