### PR TITLE
feat(config): support PLANFIX_BASE_URL override for .ru/regional accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The server requires the following environment variables for Planfix API access:
 
 - `PLANFIX_ACCOUNT` – Your Planfix account name (e.g., `yourcompany`)
 - `PLANFIX_TOKEN` – Planfix API token with necessary permissions
+- `PLANFIX_BASE_URL` – (optional) Override the REST API base URL. Defaults to `https://<PLANFIX_ACCOUNT>.planfix.com/rest/`. Set this for `.ru` and other regional installations, e.g. `https://yourcompany.planfix.ru/rest/`
+- `PLANFIX_ACCOUNT_URL` – (optional) Override the web origin used for human-facing links (task/contact/user pages). Defaults to `PLANFIX_BASE_URL` without the trailing `/rest/`
 - `PLANFIX_FIELD_ID_EMAIL` – Custom field ID for email
 - `PLANFIX_FIELD_ID_PHONE` – Custom field ID for phone
 - `PLANFIX_FIELD_ID_TELEGRAM` – Set any value to use the system Telegram field

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// config.ts reads env vars and resolves URLs at module-load time, so each case
+// resets the module registry and re-imports with a fresh environment.
+describe("config base URL resolution", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.PLANFIX_BASE_URL;
+    delete process.env.PLANFIX_ACCOUNT_URL;
+    process.env.PLANFIX_ACCOUNT = "example";
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.resetModules();
+  });
+
+  it("defaults to the .com TLD when no override is set", async () => {
+    const cfg = await import("./config.js");
+    expect(cfg.PLANFIX_BASE_URL).toBe("https://example.planfix.com/rest/");
+    expect(cfg.PLANFIX_ACCOUNT_URL).toBe("https://example.planfix.com");
+  });
+
+  it("honours PLANFIX_BASE_URL override for .ru accounts", async () => {
+    process.env.PLANFIX_BASE_URL = "https://example.planfix.ru/rest/";
+    const cfg = await import("./config.js");
+    expect(cfg.PLANFIX_BASE_URL).toBe("https://example.planfix.ru/rest/");
+    // Web origin is derived from the override (trailing "/rest/" stripped).
+    expect(cfg.PLANFIX_ACCOUNT_URL).toBe("https://example.planfix.ru");
+  });
+
+  it("allows an explicit PLANFIX_ACCOUNT_URL for the web origin", async () => {
+    process.env.PLANFIX_BASE_URL = "https://example.planfix.ru/rest/";
+    process.env.PLANFIX_ACCOUNT_URL = "https://custom.example.com";
+    const cfg = await import("./config.js");
+    expect(cfg.PLANFIX_ACCOUNT_URL).toBe("https://custom.example.com");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,18 @@ dotenv.config();
 // Planfix API configuration
 export const PLANFIX_ACCOUNT = process.env.PLANFIX_ACCOUNT || "";
 export const PLANFIX_TOKEN = process.env.PLANFIX_TOKEN || "";
-export const PLANFIX_BASE_URL = `https://${PLANFIX_ACCOUNT}.planfix.com/rest/`;
+// REST API base URL. Defaults to the .com TLD; override via PLANFIX_BASE_URL
+// for .ru and other regional Planfix installations
+// (e.g. "https://youraccount.planfix.ru/rest/").
+export const PLANFIX_BASE_URL =
+  process.env.PLANFIX_BASE_URL ||
+  `https://${PLANFIX_ACCOUNT}.planfix.com/rest/`;
+// Web origin for human-facing links (task/contact/user pages). Derived from
+// PLANFIX_BASE_URL by stripping the trailing "/rest/" so a single override
+// keeps API calls and generated links on the same host. Can be set explicitly
+// via PLANFIX_ACCOUNT_URL.
+export const PLANFIX_ACCOUNT_URL =
+  process.env.PLANFIX_ACCOUNT_URL || PLANFIX_BASE_URL.replace(/\/rest\/?$/, "");
 export const PLANFIX_HEADERS = {
   Authorization: `Bearer ${PLANFIX_TOKEN}`,
   Accept: "application/json",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import fsp from "fs/promises";
 import {
   PLANFIX_ACCOUNT,
+  PLANFIX_ACCOUNT_URL,
   PLANFIX_BASE_URL,
   PLANFIX_HEADERS,
 } from "./config.js";
@@ -154,23 +155,21 @@ export async function planfixRequest<T = unknown>({
 }
 
 export function getTaskUrl(taskId?: number): string {
-  return taskId ? `https://${PLANFIX_ACCOUNT}.planfix.com/task/${taskId}` : "";
+  return taskId ? `${PLANFIX_ACCOUNT_URL}/task/${taskId}` : "";
 }
 
 export function getCommentUrl(taskId?: number, commentId?: number): string {
   return taskId && commentId
-    ? `https://${PLANFIX_ACCOUNT}.planfix.com/task/${taskId}?comment=${commentId}`
+    ? `${PLANFIX_ACCOUNT_URL}/task/${taskId}?comment=${commentId}`
     : "";
 }
 
 export function getContactUrl(contactId?: number): string {
-  return contactId
-    ? `https://${PLANFIX_ACCOUNT}.planfix.com/contact/${contactId}`
-    : "";
+  return contactId ? `${PLANFIX_ACCOUNT_URL}/contact/${contactId}` : "";
 }
 
 export function getUserUrl(userId?: number): string {
-  return userId ? `https://${PLANFIX_ACCOUNT}.planfix.com/user/${userId}` : "";
+  return userId ? `${PLANFIX_ACCOUNT_URL}/user/${userId}` : "";
 }
 
 export async function runCli(args: string[]) {


### PR DESCRIPTION
Fixes #63.

## Problem

The REST base URL and all human-facing link builders hardcoded the `.planfix.com` TLD:

```ts
// src/config.ts
export const PLANFIX_BASE_URL = `https://${PLANFIX_ACCOUNT}.planfix.com/rest/`;
// src/helpers.ts — getTaskUrl/getCommentUrl/getContactUrl/getUserUrl
`https://${PLANFIX_ACCOUNT}.planfix.com/...`
```

Planfix also runs regional installations on `*.planfix.ru`. On such accounts the bearer token is only valid against the matching host, so **every** REST call returns `HTTP 401`, and generated links point to the wrong domain.

## Change

- **`config.ts`** — `PLANFIX_BASE_URL` is now an optional env override, defaulting to the existing `.com` URL. Added a derived `PLANFIX_ACCOUNT_URL` (web origin, override­able) obtained by stripping the trailing `/rest/`, so a single variable keeps API calls and links on the same host.
- **`helpers.ts`** — the four URL builders use `PLANFIX_ACCOUNT_URL` instead of the hardcoded domain.
- **`config.test.ts`** — new tests: default `.com`, `.ru` override, explicit `PLANFIX_ACCOUNT_URL`.
- **`README.md`** — documents both variables.

## Backwards compatibility

Fully backwards-compatible — with neither variable set, behaviour is identical to before (`https://<account>.planfix.com/rest/`). `.ru` users just add:

```
PLANFIX_BASE_URL=https://youraccount.planfix.ru/rest/
```

## Verification

- `npm run test:unit` → **182 passed (41 files)**, including the 3 new config tests.
- `npm run typecheck` → no new errors (the pre-existing `src/types.ts:14` zod typing error is present on `master` and unrelated to this change).
- `npx prettier --check` → clean on all touched files.

Tested live against a real `.planfix.ru` account: with the override, `user/list`, `task/list`, comment creation and task updates all return `success` (they returned `401` before).